### PR TITLE
feat: default selected vault [WEB-587]

### DIFF
--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -52,8 +52,13 @@ export const DepositTx: FC<DepositTxProps> = ({ onClose, children, ...props }) =
     }
 
     if (!selectedVault) {
-      // TODO: DEFINE DEFAULT SELECTED VAULT ADDRESS CRITERIA
-      dispatch(VaultsActions.setSelectedVaultAddress({ vaultAddress: '0xE14d13d8B3b85aF791b2AADD661cDBd5E6097Db1' }));
+      const matchingVault = vaults.find((vault) => vault.token.address === selectedSellTokenAddress);
+      const highestYieldingVault = vaults.reduce((prev, current) => (prev.apyData > current.apyData ? prev : current));
+      dispatch(
+        VaultsActions.setSelectedVaultAddress({
+          vaultAddress: matchingVault?.address ?? highestYieldingVault.address,
+        })
+      );
       setAllowVaultSelect(true);
     }
 


### PR DESCRIPTION
- Selected default vault match selected sell token.
- Selected default vault set to highest yielding vault if no underlying token match is available.