### PR TITLE
feat: block network change on load [WEB-932]

### DIFF
--- a/src/client/components/app/Navbar/index.tsx
+++ b/src/client/components/app/Navbar/index.tsx
@@ -84,6 +84,7 @@ interface NavbarProps {
   selectedNetwork: Network;
   networkOptions: Network[];
   onNetworkChange: (network: string) => void;
+  disableNetworkChange?: boolean;
 }
 
 export const Navbar = ({
@@ -95,6 +96,7 @@ export const Navbar = ({
   selectedNetwork,
   networkOptions,
   onNetworkChange,
+  disableNetworkChange,
 }: NavbarProps) => {
   const { isMobile } = useWindowDimensions();
   const { NETWORK_SETTINGS } = getConfig();
@@ -122,6 +124,7 @@ export const Navbar = ({
           setSelected={(option) => onNetworkChange(option.value)}
           options={dropdownNetworkOptions}
           hideIcons={isMobile}
+          disabled={disableNetworkChange}
         />
 
         <ConnectWalletButton

--- a/src/client/containers/Layout/index.tsx
+++ b/src/client/containers/Layout/index.tsx
@@ -10,14 +10,20 @@ import {
   VaultsActions,
   LabsActions,
   IronBankActions,
+  VaultsSelectors,
+  LabsSelectors,
+  IronBankSelectors,
   WalletSelectors,
+  TokensSelectors,
   NetworkSelectors,
+  AppSelectors,
+  ModalSelectors,
   SettingsSelectors,
   AlertsActions,
   NetworkActions,
 } from '@store';
 
-import { useAppTranslation, useAppDispatch, useAppSelector, useWindowDimensions } from '@hooks';
+import { useAppTranslation, useAppDispatch, useAppSelector, useWindowDimensions, useIsMounting } from '@hooks';
 import { Navigation, Navbar, Footer } from '@components/app';
 import { Modals, Alerts } from '@containers';
 import { getConfig } from '@config';
@@ -73,6 +79,7 @@ const Content = styled.div<{ collapsedSidebar?: boolean; useTabbar?: boolean }>`
 export const Layout: FC = ({ children }) => {
   const { t } = useAppTranslation('common');
   const dispatch = useAppDispatch();
+  const isMounting = useIsMounting();
   const location = useLocation();
   const { SUPPORTED_NETWORKS } = getConfig();
   const { isMobile } = useWindowDimensions();
@@ -81,7 +88,23 @@ export const Layout: FC = ({ children }) => {
   const currentNetwork = useAppSelector(NetworkSelectors.selectCurrentNetwork);
   const collapsedSidebar = useAppSelector(SettingsSelectors.selectSidebarCollapsed);
   const history = useHistory();
+
   let isFetching = false;
+  const activeModal = useAppSelector(ModalSelectors.selectActiveModal);
+  const appStatus = useAppSelector(AppSelectors.selectAppStatus);
+  const tokensStatus = useAppSelector(TokensSelectors.selectWalletTokensStatus);
+  const vaultsStatus = useAppSelector(VaultsSelectors.selectVaultsStatus);
+  const labsStatus = useAppSelector(LabsSelectors.selectLabsStatus);
+  const ironBankStatus = useAppSelector(IronBankSelectors.selectIronBankStatus);
+  const generalLoading =
+    (appStatus.loading ||
+      tokensStatus.loading ||
+      vaultsStatus.loading ||
+      labsStatus.loading ||
+      ironBankStatus.loading ||
+      isMounting ||
+      isFetching) &&
+    !activeModal;
 
   // const path = useAppSelector(({ route }) => route.path);
   const path = location.pathname.toLowerCase().split('/')[1];

--- a/src/client/containers/Layout/index.tsx
+++ b/src/client/containers/Layout/index.tsx
@@ -261,6 +261,7 @@ export const Layout: FC = ({ children }) => {
           selectedNetwork={currentNetwork}
           networkOptions={SUPPORTED_NETWORKS}
           onNetworkChange={(network) => dispatch(NetworkActions.changeNetwork({ network: network as Network }))}
+          disableNetworkChange={generalLoading}
         />
         {children}
         <Footer />


### PR DESCRIPTION
- Temporarily disable network change button when app is loading to prevent bug of displaying data from incorrect networks.