### PR TITLE
refactor: temp remove gas service [WEB-949]

### DIFF
--- a/src/core/services/TransactionService.ts
+++ b/src/core/services/TransactionService.ts
@@ -13,7 +13,8 @@ export class TransactionServiceImpl implements TransactionService {
     let gasFees: GasFees = {};
     try {
       if (network === 'mainnet') {
-        gasFees = await this.gasService.getGasFees();
+        // TODO: Analyze if gas service required
+        // gasFees = await this.gasService.getGasFees();
       }
     } catch (error) {
       console.error(error);
@@ -28,7 +29,7 @@ export class TransactionServiceImpl implements TransactionService {
       const txArgs = args ? [...args, txOverrides] : [txOverrides];
       const tx = await fn(...txArgs);
       return tx;
-    } catch (error) {
+    } catch (error: any) {
       // Retry as a legacy tx, for specific error in metamask v10 + ledger transactions
       // Metamask RPC Error: Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559
       if (error.code === -32602) {


### PR DESCRIPTION
- Removes fetching gas from Blocknative in favor of native Ethers gas calcs.