### PR TITLE
feat: Hide Token Dust In Wallet View [WEB-711]

### DIFF
--- a/src/client/components/app/DetailCard/index.tsx
+++ b/src/client/components/app/DetailCard/index.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { Card, CardHeader, CardContent, CardElement, CardEmptyList } from '@components/common';
+import { Card, CardHeader, CardContent, CardElement, CardEmptyList, ToggleButton } from '@components/common';
 import { sort } from '@utils';
+import { filter } from 'lodash';
 
 const StyledCardElement = styled(CardElement)<{ stripes?: boolean }>`
   display: flex;
@@ -57,12 +58,22 @@ const StyledCardContent = styled(CardContent)<{ wrap?: boolean; pointer?: boolea
 `;
 
 const StyledCardHeader = styled(CardHeader)`
+  display: flex;
+  flex-wrap: center;
+  justify-content: space-between;
   margin-bottom: 0.6rem;
 `;
 
 const StyledCard = styled(Card)`
   padding: ${({ theme }) => theme.card.padding} 0;
   width: 100%;
+`;
+
+const SectionContent = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  align-items: center;
 `;
 
 interface Metadata<T> {
@@ -89,6 +100,8 @@ interface DetailCardProps<T> {
   SearchBar?: ReactNode;
   searching?: boolean;
   onAction?: (item: T) => void;
+  filterBy?: (item: T) => boolean;
+  filterLabel?: string;
 }
 
 export const DetailCard = <T,>({
@@ -101,11 +114,16 @@ export const DetailCard = <T,>({
   SearchBar,
   searching,
   onAction,
+  filterBy,
+  filterLabel,
   ...props
 }: DetailCardProps<T>) => {
   const [sortedData, setSortedData] = useState(initialSortBy ? sort(data, initialSortBy) : data);
   const [sortedBy, setSortedBy] = useState(initialSortBy);
   const [order, setOrder] = useState<'asc' | 'desc'>('desc');
+  const [filterToggle, setFilterToggle] = useState(filterBy ? false : true);
+  const filteredData = filterBy ? sortedData.filter(filterBy) : sortedData;
+  const displayData = filterToggle ? sortedData : filteredData;
 
   const handleSort = (key: Extract<keyof T, string>) => {
     if (sortedBy === key) {
@@ -128,10 +146,17 @@ export const DetailCard = <T,>({
 
   return (
     <StyledCard {...props}>
-      <StyledCardHeader header={header} />
+      <StyledCardHeader header={header}>
+        {!!filterBy && (
+          <SectionContent>
+            {filterLabel}
+            <ToggleButton selected={filterToggle} setSelected={setFilterToggle} />
+          </SectionContent>
+        )}
+      </StyledCardHeader>
       {SearchBar}
 
-      {!!sortedData.length && (
+      {!!displayData.length && (
         <CardContent>
           {metadata.map(
             ({ key, sortable, hide, className, transform, format, ...rest }) =>
@@ -150,7 +175,7 @@ export const DetailCard = <T,>({
         </CardContent>
       )}
 
-      {sortedData.map((item, i) => (
+      {displayData.map((item, i) => (
         <StyledCardContent
           key={`content-${i}`}
           wrap={wrap}
@@ -179,7 +204,7 @@ export const DetailCard = <T,>({
         </StyledCardContent>
       ))}
 
-      {!sortedData.length && <CardEmptyList searching={searching} />}
+      {!displayData.length && <CardEmptyList searching={searching} />}
     </StyledCard>
   );
 };

--- a/src/client/routes/Wallet/index.tsx
+++ b/src/client/routes/Wallet/index.tsx
@@ -23,6 +23,7 @@ import {
   Amount,
 } from '@components/app';
 import { SpinnerLoading, Text } from '@components/common';
+import { getConstants } from '@config/constants';
 import { halfWidthCss, humanizeAmount, normalizeAmount, normalizeUsdc } from '@src/utils';
 import { device } from '@themes/default';
 
@@ -84,6 +85,7 @@ export const Wallet = () => {
   const appStatus = useAppSelector(AppSelectors.selectAppStatus);
   const tokensListStatus = useAppSelector(TokensSelectors.selectWalletTokensStatus);
   const generalLoading = (appStatus.loading || tokensListStatus.loading || isMounting) && !activeModal;
+  const { DUST_AMOUNT_USD } = getConstants();
 
   const actionHandler = (action: string, tokenAddress: string) => {
     switch (action) {
@@ -118,6 +120,10 @@ export const Wallet = () => {
         disabled: !walletIsConnected || !ironBankUnderlyingTokens.includes(tokenAddress),
       },
     ];
+  };
+
+  const filterDustTokens = (item: { balanceUsdc: string }) => {
+    return parseInt(item.balanceUsdc) > parseInt(DUST_AMOUNT_USD);
   };
 
   return (
@@ -221,6 +227,8 @@ export const Wallet = () => {
           }))}
           initialSortBy="balanceUsdc"
           wrap
+          filterBy={filterDustTokens}
+          filterLabel="Show Dust"
         />
       )}
     </ViewContainer>

--- a/src/config/constants/index.ts
+++ b/src/config/constants/index.ts
@@ -74,5 +74,6 @@ export const getConstants = memoize((): Constants => {
     DEFAULT_THEME: 'light',
     AVAILABLE_THEMES: ['light', 'dark', 'cyberpunk', 'classic'],
     DEFAULT_ALERT_TIMEOUT: 3000,
+    DUST_AMOUNT_USD: '10000000',
   };
 });

--- a/src/core/types/Config.ts
+++ b/src/core/types/Config.ts
@@ -39,4 +39,5 @@ export interface Constants {
   DEFAULT_THEME: Theme;
   AVAILABLE_THEMES: Theme[];
   DEFAULT_ALERT_TIMEOUT: number;
+  DUST_AMOUNT_USD: string;
 }


### PR DESCRIPTION
Fixes [#329 ](https://github.com/yearn/yearn-finance-v3/issues/329)

**Definition of Done:** 

- [x] A toggle should be displayed in the Token Card of the Wallet page.
- [x] By default, dust balance of tokens should be hidden (value <$10).
- [x] On toggle click, dust tokens should display/hide in the Token Card.
- [x] Dust amount should be configurable by value in USD.

![image](https://user-images.githubusercontent.com/92565284/138815848-ebf8f59e-9309-49bf-97da-e5e9e2d3aa7a.png)
![image](https://user-images.githubusercontent.com/92565284/138815936-e514081b-535e-4557-87ae-2bf3410d58d1.png)
