### PR TITLE
feat: hide IronBank on ledger Iframe

### DIFF
--- a/src/client/components/app/Navigation/NavSidebar.tsx
+++ b/src/client/components/app/Navigation/NavSidebar.tsx
@@ -5,7 +5,7 @@ import { useAppTranslation, useAppSelector } from '@hooks';
 import { SettingsSelectors } from '@store';
 import { NavigationLink } from '@components/app';
 import { Icon, Logo } from '@components/common';
-import { inIframe } from '@utils';
+import { inLedgerIframe } from '@utils';
 
 const linkHoverFilter = 'brightness(90%)';
 const linkTransition = 'filter 200ms ease-in-out';
@@ -131,7 +131,7 @@ export const NavSidebar = ({ navLinks, ...props }: NavSidebarProps) => {
   //   dispatch(SettingsActions.toggleSidebar());
   // };
 
-  const isInIframe = inIframe();
+  const isInIframe = inLedgerIframe();
   const linkList = (
     <LinkList className="link-list">
       {navLinks.map((link, index) => {

--- a/src/client/components/app/Navigation/NavSidebar.tsx
+++ b/src/client/components/app/Navigation/NavSidebar.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation, useAppSelector } from '@hooks';
 import { SettingsSelectors } from '@store';
 import { NavigationLink } from '@components/app';
 import { Icon, Logo } from '@components/common';
+import { inIframe } from '@utils';
 
 const linkHoverFilter = 'brightness(90%)';
 const linkTransition = 'filter 200ms ease-in-out';
@@ -130,9 +131,13 @@ export const NavSidebar = ({ navLinks, ...props }: NavSidebarProps) => {
   //   dispatch(SettingsActions.toggleSidebar());
   // };
 
+  const isInIframe = inIframe();
   const linkList = (
     <LinkList className="link-list">
       {navLinks.map((link, index) => {
+        if (isInIframe && link.hideIframe) {
+          return null;
+        }
         return (
           <RouterLink to={link.to} key={index} selected={currentPath === link.to}>
             <LinkIcon Component={link.icon} /> <LinkText>{t(link.text)}</LinkText>

--- a/src/client/components/app/Navigation/index.tsx
+++ b/src/client/components/app/Navigation/index.tsx
@@ -12,6 +12,7 @@ export interface NavigationLink {
   to: string;
   text: string;
   icon: ElementType;
+  hideIframe?: boolean;
   hideMobile?: boolean;
 }
 
@@ -42,6 +43,7 @@ const navLinks = [
     to: '/ironbank',
     text: 'navigation.ironbank',
     icon: IronBankIcon,
+    hideIframe: true,
   },
   {
     to: '/settings',

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -52,3 +52,14 @@ export const inIframe = () => {
     return true;
   }
 };
+
+export const inLedgerIframe = () => {
+  try {
+    return (
+      window.self !== window.top &&
+      (window?.location?.ancestorOrigins?.[0]?.includes('ledger') || window?.navigator?.userAgent.includes('Firefox'))
+    );
+  } catch (e) {
+    return true;
+  }
+};


### PR DESCRIPTION
## Description
Based on a request from the Ledger Team, hide the IronBank menu when the dApp runs in an Iframe (Ledger Live) to prevent user from interacting with IronBank.
This restriction will be removed once the plugin is updated with IB support

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Change details
- Add a new `inLedgerIframe` function, checking the Iframe + Ledger status.
- Add a new `hideIframe?: boolean;` for the `NavigationLink` type
- Hide Navigation Link when hideIframe is `true

## Resources
*NA*