### PR TITLE
Fix vault fetching on network switch

### DIFF
--- a/src/client/routes/VaultDetail/index.tsx
+++ b/src/client/routes/VaultDetail/index.tsx
@@ -86,7 +86,7 @@ export const VaultDetail = () => {
     return () => {
       dispatch(VaultsActions.clearSelectedVaultAndStatus());
     };
-  }, []);
+  }, [currentNetwork]);
 
   useEffect(() => {
     const loading = tokensStatus.loading;


### PR DESCRIPTION
Issue: switching back and forth between Ethereum and Fantom on a valid mainnet vault causes this result

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7850202/147313612-c71f14a3-7404-492f-b83f-a57a4d423611.png">


Fix: trigger effect on network switch that calls `setSelectedVaultAddress` for address in url