### PR TITLE
fix: yvboost deposit expected token amount [WEB-1069]

### DIFF
--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -189,7 +189,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
 
   const amountValue = toBN(amount).times(normalizeAmount(selectedSellToken.priceUsdc, USDC_DECIMALS)).toString();
   const expectedAmount = toBN(debouncedAmount).gt(0)
-    ? normalizeAmount(expectedTxOutcome?.targetUnderlyingTokenAmount, selectedLab?.token.decimals)
+    ? normalizeAmount(expectedTxOutcome?.targetTokenAmount, toBN(selectedLab?.decimals).toNumber())
     : '';
   const expectedAmountValue = toBN(debouncedAmount).gt(0)
     ? normalizeAmount(expectedTxOutcome?.targetTokenAmountUsdc, USDC_DECIMALS)


### PR DESCRIPTION
- Display the correct expected vault token amount when depositing to yvboost.