### PR TITLE
fix: yvBoost balance displayed correctly [WEB-1080]

### DIFF
--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -358,7 +358,7 @@ export const Labs = () => {
                 {
                   key: 'balance',
                   header: t('components.list-card.balance'),
-                  format: (lab) => humanize('amount', lab[lab.mainPositionKey].userDeposited, lab.token.decimals, 4),
+                  format: (lab) => humanize('amount', lab[lab.mainPositionKey].userBalance, lab.token.decimals, 4),
                   sortable: true,
                   width: '13rem',
                   className: 'col-balance',

--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -358,7 +358,7 @@ export const Labs = () => {
                 {
                   key: 'balance',
                   header: t('components.list-card.balance'),
-                  format: (lab) => humanize('amount', lab[lab.mainPositionKey].userBalance, lab.token.decimals, 4),
+                  format: (lab) => humanize('amount', lab[lab.mainPositionKey].userBalance, parseInt(lab.decimals), 4),
                   sortable: true,
                   width: '13rem',
                   className: 'col-balance',

--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -383,7 +383,7 @@ export class LabServiceImpl implements LabService {
         typeId: 'STAKE',
         balance: pGaugeBalanceOf.toString(),
         underlyingTokenBalance: {
-          amount: pGaugeBalanceOf.toString(),
+          amount: pGaugeBalanceOf.toString(), // TODO user true uderlying balance
           amountUsdc: toBN(normalizeAmount(pGaugeBalanceOf.toString(), pJarData.decimals))
             .times(pJarPricePerToken)
             .times(10 ** USDC_DECIMALS)


### PR DESCRIPTION
Since underlyingToken of yvBoost is yveCrv we were displaying the underlyingTokenBalance which in the case of "normal" vaults is correct, but since yvBoost is different we need to show vaultBalance.

As fix for labs we will display the userBalance instead of underlyingUserBalance.