### PR TITLE
[WEB-1223-450] refactor(yearnsdk): use only one instance at a time of the yearn sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/redux-logger": "3.0.9",
     "@types/styled-components": "5.1.12",
     "@types/styled-system": "5.1.13",
-    "@yfi/sdk": "1.0.25",
+    "@yfi/sdk": "1.0.26",
     "awilix": "4.3.4",
     "axios": "0.21.1",
     "bignumber.js": "9.0.1",

--- a/src/core/frameworks/yearnSdk/index.ts
+++ b/src/core/frameworks/yearnSdk/index.ts
@@ -4,30 +4,40 @@ import { getNetworkId, getProviderType } from '@utils';
 import { YearnSdk, SdkNetwork, Web3Provider, Network, Config } from '@types';
 
 export class YearnSdkImpl implements YearnSdk {
-  private instances: Map<Network, Yearn<SdkNetwork>> = new Map<Network, Yearn<SdkNetwork>>();
+  private instance: Yearn<SdkNetwork> | null;
+  private SUPPORTED_NETWORKS: Network[];
+  private web3Provider: Web3Provider;
+  private currentNetwork: Network | null;
 
   constructor({ web3Provider, config }: { web3Provider: Web3Provider; config: Config }) {
     const { SUPPORTED_NETWORKS } = config;
 
-    SUPPORTED_NETWORKS.forEach((network) => {
-      const providerType = getProviderType(network);
-      const provider = web3Provider.getInstanceOf(providerType);
-      const networkId = getNetworkId(network) as SdkNetwork;
-      const sdkInstance = new Yearn(networkId, {
-        provider,
-      });
-      this.register(network, sdkInstance);
-    });
+    this.web3Provider = web3Provider;
+    this.SUPPORTED_NETWORKS = SUPPORTED_NETWORKS;
+    this.currentNetwork = null;
+    this.instance = null;
   }
 
-  public hasInstanceOf(network: Network): boolean {
-    return this.instances.has(network);
+  public hasInstanceOf(network: Network) {
+    return network === this.currentNetwork || !this.instance;
   }
 
   public getInstanceOf(network: Network): Yearn<SdkNetwork> {
-    const instance = this.instances.get(network);
+    const instance = this.instance;
 
-    if (!instance) {
+    if (!instance || network !== this.currentNetwork) {
+      if (this.SUPPORTED_NETWORKS.includes(network)) {
+        this.currentNetwork = network;
+        const providerType = getProviderType(network);
+        const provider = this.web3Provider.getInstanceOf(providerType);
+        const networkId = getNetworkId(network) as SdkNetwork;
+        const sdkInstance = new Yearn(networkId, {
+          provider,
+        });
+        this.register(network, sdkInstance);
+
+        return sdkInstance;
+      }
       throw new Error(`YearnSdkImpl has no "${network}" network registered`);
     }
 
@@ -35,6 +45,7 @@ export class YearnSdkImpl implements YearnSdk {
   }
 
   public register(network: Network, instance: Yearn<SdkNetwork>): void {
-    this.instances.set(network, instance);
+    this.instance = instance;
+    this.currentNetwork = network;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,10 +4191,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@yfi/sdk@1.0.25":
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.0.25.tgz#4241b80bf3ce9690bb23c8492b279ded7a248f5b"
-  integrity sha512-Z8AixPc9md2mbvA4KSa0wneZic67tuv3fzZTo9LyJb574FtCBH8ZCp7s/M576nTQdpLtCrDjrJXxncNHY/GEVw==
+"@yfi/sdk@1.0.26":
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.0.26.tgz#d4dde0205f89e08ef36ade6bc1a9a3844a9a917d"
+  integrity sha512-HnNct+f4pRHJPpn0hNJzhx2EELZsONWYPAVtg5s1KXJsEhBU1I9mVYQazmzujLSo1b7rRB7Ma4L3GGfrlNwpPQ==
   dependencies:
     bignumber.js "9.0.1"
     cross-fetch "3.1.4"


### PR DESCRIPTION
There is no actual need for us to have several instances of the Yearn sdk running at all times, and we need this to fix the  https://github.com/yearn/yearn-sdk/pull/191
