### PR TITLE
fix: tw.card img

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,14 +12,14 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Yearn Finance" />
     <meta property="og:description" content="DeFi made simple." />
-    <meta property="og:image" content="%PUBLIC_URL%/share.png" />
+    <meta property="og:image" content="https://yearn.finance/share.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@iearnfinance" />
     <meta name="twitter:creator" content="@iearnfinance" />
     <meta name="twitter:title" content="Yearn Finance" />
     <meta name="twitter:description" content="DeFi made simple." />
-    <meta name="twitter:image" content="%PUBLIC_URL%/share.png?twitter" />
+    <meta name="twitter:image" content="https://yearn.finance/share.png?twitter" />
 
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Fixes https://github.com/yearn/yearn-finance-v3/issues/497

It appears that `%PUBLIC_URL%` is not working in the `content` tag, only `href` (like for the manifest file) so I've changed it to be static. It should now allow twitter to grab this image https://yearn.finance/share.png for the thumbnail

<img width="506" alt="yearn_finance" src="https://user-images.githubusercontent.com/78794805/155819696-96ee83e6-30e6-4a39-945b-52a39cc208e8.png">

