### PR TITLE
fix: Yield under modal displaying 0

### DIFF
--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -21,7 +21,7 @@ import {
   validateSlippage,
   validateNetwork,
   getZapInContractAddress,
-  formatPercent,
+  formatApy,
 } from '@utils';
 import { getConfig } from '@config';
 
@@ -171,14 +171,14 @@ export const DepositTx: FC<DepositTxProps> = ({
 
   const vaultsOptions = vaults
     .filter(({ address }) => allowVaultSelect || selectedVault.address === address)
-    .map(({ address, displayName, displayIcon, DEPOSIT, token, apyData }) => ({
+    .map(({ address, displayName, displayIcon, DEPOSIT, token, apyData, apyMetadata }) => ({
       address,
       symbol: displayName,
       icon: displayIcon,
       balance: DEPOSIT.userDeposited,
       balanceUsdc: DEPOSIT.userDepositedUsdc,
       decimals: token.decimals,
-      yield: formatPercent(apyData, 2),
+      yield: formatApy(apyData, apyMetadata?.type),
     }));
   const selectedVaultOption = vaultsOptions.find(({ address }) => address === selectedVault.address)!;
 

--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -24,7 +24,7 @@ import {
   validateYvBoostEthActionsAllowance,
   validateSlippage,
   validateNetwork,
-  formatPercent,
+  formatApy,
 } from '@utils';
 import { getConfig } from '@config';
 
@@ -184,7 +184,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
     balance: selectedLab.DEPOSIT.userBalance,
     balanceUsdc: selectedLab.DEPOSIT.userDepositedUsdc,
     decimals: toBN(selectedLab.decimals).toNumber(),
-    yield: formatPercent(selectedLab.apyData, 2),
+    yield: formatApy(selectedLab.apyData, selectedLab.apyMetadata?.type || ''),
   };
 
   const amountValue = toBN(amount).times(normalizeAmount(selectedSellToken.priceUsdc, USDC_DECIMALS)).toString();

--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -184,7 +184,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
     balance: selectedLab.DEPOSIT.userBalance,
     balanceUsdc: selectedLab.DEPOSIT.userDepositedUsdc,
     decimals: toBN(selectedLab.decimals).toNumber(),
-    yield: formatApy(selectedLab.apyData, selectedLab.apyMetadata?.type || ''),
+    yield: formatApy(selectedLab.apyData, selectedLab.apyMetadata?.type),
   };
 
   const amountValue = toBN(amount).times(normalizeAmount(selectedSellToken.priceUsdc, USDC_DECIMALS)).toString();

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -305,8 +305,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
             )}
             {yieldPercent && (
               <StyledText>
-                {t('components.transaction.token-input.yield')}{' '}
-                <ContrastText>{yieldPercent === '0.00%' ? 'NEW ✨' : yieldPercent}</ContrastText>
+                {t('components.transaction.token-input.yield')} <ContrastText>{yieldPercent}</ContrastText>
               </StyledText>
             )}
           </TokenExtras>

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -305,7 +305,8 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
             )}
             {yieldPercent && (
               <StyledText>
-                {t('components.transaction.token-input.yield')} <ContrastText>{yieldPercent}</ContrastText>
+                {t('components.transaction.token-input.yield')}{' '}
+                <ContrastText>{yieldPercent === '0.00%' ? 'NEW ✨' : yieldPercent}</ContrastText>
               </StyledText>
             )}
           </TokenExtras>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -96,6 +96,7 @@ export const formatUsd = (amount?: Amount, decimals = 2): FormattedAmount =>
   toBN(amount).toFormat(decimals, { ...FORMAT, prefix: '$ ' });
 
 export const formatApy = (apyData: Fraction, apyType: string): FormattedAmount => {
+  if (apyType === 'error') return '-';
   if (apyType === 'new') return 'NEW ✨';
   if (apyType === 'n/a') return 'N/A';
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -95,7 +95,7 @@ export const formatPercent = (amount: Fraction, decimals = 2): FormattedAmount =
 export const formatUsd = (amount?: Amount, decimals = 2): FormattedAmount =>
   toBN(amount).toFormat(decimals, { ...FORMAT, prefix: '$ ' });
 
-export const formatApy = (apyData: Fraction, apyType: string): FormattedAmount => {
+export const formatApy = (apyData: Fraction, apyType?: string): FormattedAmount => {
   if (apyType === 'error') return '-';
   if (apyType === 'new') return 'NEW ✨';
   if (apyType === 'n/a') return 'N/A';


### PR DESCRIPTION
Fixes https://github.com/yearn/yearn-finance-v3/issues/493

Uses the util function and finds the type (e.g "new") from the apy metadata