### PR TITLE
Integrate the Rave Names FNS into the wallet address display

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "5.4.5",
+    "fns-helper": "1.2.0",
     "husky": "5.2.0",
     "i18next": "20.4.0",
     "i18next-browser-languagedetector": "6.1.2",

--- a/src/core/services/UserService.ts
+++ b/src/core/services/UserService.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
-import { Contract } from 'ethers';
+import { Contract, ethers } from 'ethers';
+import { fns } from 'fns-helper';
 
 import { GetAddressEnsNameProps, UserService, Web3Provider, NftBalances, Config } from '@types';
 import { getContract } from '@frameworks/ethers';
@@ -16,11 +17,25 @@ export class UserServiceImpl implements UserService {
     this.config = config;
   }
 
+  public async isFnsName(address) {
+    var name = await fns.functions.getNameFromOwner(address);
+    console.log('Coolnesssssss  ' + name);
+    return [name.toString().split('').length > 0];
+  }
+
   public async getAddressEnsName(props: GetAddressEnsNameProps) {
+    console.log('ysjsjsjsjsjsjjse');
     const { address } = props;
+    const res = await this.isFnsName(address);
+    console.log(res);
     const provider = this.web3Provider.getInstanceOf('ethereum');
-    const addressEnsName = await provider.lookupAddress(address);
-    return addressEnsName;
+    var addressEnsName;
+    if (res[0]) {
+      addressEnsName = await fns.functions.getNameFromOwner(address);
+    } else {
+      addressEnsName = await provider.lookupAddress(address);
+    }
+    return addressEnsName.toString().toLowerCase();
   }
 
   /* -------------------------------------------------------------------------- */

--- a/src/core/services/UserService.ts
+++ b/src/core/services/UserService.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { Contract, ethers } from 'ethers';
+import { Contract } from 'ethers';
 import { fns } from 'fns-helper';
 
 import { GetAddressEnsNameProps, UserService, Web3Provider, NftBalances, Config } from '@types';
@@ -19,12 +19,10 @@ export class UserServiceImpl implements UserService {
 
   public async isFnsName(address) {
     var name = await fns.functions.getNameFromOwner(address);
-    console.log('Coolnesssssss  ' + name);
     return [name.toString().split('').length > 0];
   }
 
   public async getAddressEnsName(props: GetAddressEnsNameProps) {
-    console.log('ysjsjsjsjsjsjjse');
     const { address } = props;
     const res = await this.isFnsName(address);
     console.log(res);


### PR DESCRIPTION
Uses the `fns-helper` module to allow for display of Rave Names alongside ENS. 