### PR TITLE
fix: Add vault token to MetaMask

### DIFF
--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -293,9 +293,10 @@ export const VaultDetailPanels = ({
   );
 
   const handleAddToken = () => {
-    const { address, symbol, decimals, icon } = selectedVault.token;
+    const { address, displayName, decimals, displayIcon } = selectedVault;
+
     if (context?.wallet.addToken) {
-      context?.wallet.addToken(address, symbol.substr(0, 11), decimals, icon || '');
+      context?.wallet.addToken(address, `y${displayName.substring(0, 10)}`, Number(decimals), displayIcon || '');
     }
   };
 

--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -293,10 +293,10 @@ export const VaultDetailPanels = ({
   );
 
   const handleAddToken = () => {
-    const { address, displayName, decimals, displayIcon } = selectedVault;
+    const { address, symbol, decimals, displayIcon } = selectedVault;
 
     if (context?.wallet.addToken) {
-      context?.wallet.addToken(address, `y${displayName.substring(0, 10)}`, Number(decimals), displayIcon || '');
+      context?.wallet.addToken(address, symbol.substring(0, 11), Number(decimals), displayIcon || '');
     }
   };
 

--- a/src/core/store/modules/vaults/vaults.selectors.ts
+++ b/src/core/store/modules/vaults/vaults.selectors.ts
@@ -257,6 +257,7 @@ function createVault(props: CreateVaultProps): GeneralVaultView {
     defaultDisplayToken: vaultData.metadata.defaultDisplayToken,
     vaultBalance: vaultData.underlyingTokenBalance.amount,
     decimals: vaultData.decimals,
+    symbol: vaultData.symbol,
     vaultBalanceUsdc: vaultData.underlyingTokenBalance.amountUsdc,
     depositLimit: vaultData.metadata.depositLimit ?? '0',
     emergencyShutdown: vaultData.metadata.emergencyShutdown,

--- a/src/core/types/Vault.ts
+++ b/src/core/types/Vault.ts
@@ -16,6 +16,7 @@ export interface GeneralVaultView {
   displayIcon: string;
   defaultDisplayToken: string;
   decimals: string;
+  symbol: string;
   vaultBalance: string;
   vaultBalanceUsdc: string;
   depositLimit: string;


### PR DESCRIPTION
Fixes https://github.com/yearn/yearn-finance-v3/issues/496

- Add the vault symbol to the vault selector
- Use the vault symbol instead of the token symbol when adding the token to metamask

<img width="472" alt="Screen Shot 2022-03-08 at 11 41 01 am" src="https://user-images.githubusercontent.com/78794805/157142766-2bd33741-e88f-4b88-85c8-1704f299bf64.png">

