### PR TITLE
fix: quickfix for subgraph date format issue

### DIFF
--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -300,7 +300,6 @@ export const VaultDetailPanels = ({
     }
   };
 
-  console.log('chart shit', chartData, chartValue, selectedUnderlyingData)
   // TODO: REMOVE THIS QUICKFIX
   let selectedData = selectedUnderlyingData ? chartData?.underlying ?? [] : chartData?.usd ?? [];
   let dataToShow = selectedData;

--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -300,6 +300,23 @@ export const VaultDetailPanels = ({
     }
   };
 
+  console.log('chart shit', chartData, chartValue, selectedUnderlyingData)
+  // TODO: REMOVE THIS QUICKFIX
+  let selectedData = selectedUnderlyingData ? chartData?.underlying ?? [] : chartData?.usd ?? [];
+  let dataToShow = selectedData;
+  const dateRegex = new RegExp(/^\d\d\d\d-\d\d-\d\d$/)
+  selectedData.forEach(dataPoint => {
+    if (!dataToShow.length) {
+      return;
+    }
+
+    dataPoint.data.forEach((point: { x: string }) => {
+      if (!dateRegex.test(point.x)) {
+        dataToShow = [];
+      }
+    });
+  });
+
   return (
     <>
       <Row>
@@ -425,7 +442,7 @@ export const VaultDetailPanels = ({
           </ChartValueContainer>
 
           <StyledLineChart
-            chartData={selectedUnderlyingData ? chartData?.underlying ?? [] : chartData?.usd ?? []}
+            chartData={dataToShow}
             tooltipLabel={t('vaultdetails:performance-panel.earnings-over-time')}
             customSymbol={selectedUnderlyingData ? selectedVault?.token?.symbol : undefined}
           />


### PR DESCRIPTION
Adding a temporal fix to ignore dates that are not valid for the graph so the page does not crash.


Lets remove this fix asap and implement the correct one in how the API returns the data