### PR TITLE
fix: avoid showing vault graph for single data point

### DIFF
--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -303,7 +303,7 @@ export const VaultDetailPanels = ({
 
   const shouldShowChart = (data: Serie[]): boolean => {
     // Only show earnings chart if more than one data point
-    return data.length > 0 && data[0].data.length > 1;
+    return data.length > 0 && data[0].data?.length > 1;
   };
 
   // TODO: REMOVE THIS QUICKFIX

--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
 import styled from 'styled-components';
+import { Serie } from '@nivo/line';
 
 import { formatApy, formatAmount, USDC_DECIMALS, humanize, formatUsd, isCustomApyType } from '@utils';
 import { AppContext } from '@context';
@@ -300,6 +301,11 @@ export const VaultDetailPanels = ({
     }
   };
 
+  const shouldShowChart = (data: Serie[]): boolean => {
+    // Only show earnings chart if more than one data point
+    return data.length > 0 && data[0].data.length > 1;
+  };
+
   // TODO: REMOVE THIS QUICKFIX
   let selectedData = selectedUnderlyingData ? chartData?.underlying ?? [] : chartData?.usd ?? [];
   let dataToShow = selectedData;
@@ -440,11 +446,13 @@ export const VaultDetailPanels = ({
             <ChartValue>{chartValueText}</ChartValue>
           </ChartValueContainer>
 
-          <StyledLineChart
-            chartData={dataToShow}
-            tooltipLabel={t('vaultdetails:performance-panel.earnings-over-time')}
-            customSymbol={selectedUnderlyingData ? selectedVault?.token?.symbol : undefined}
-          />
+          {shouldShowChart(dataToShow) && (
+            <StyledLineChart
+              chartData={dataToShow}
+              tooltipLabel={t('vaultdetails:performance-panel.earnings-over-time')}
+              customSymbol={selectedUnderlyingData ? selectedVault?.token?.symbol : undefined}
+            />
+          )}
         </VaultChart>
       )}
     </>


### PR DESCRIPTION
Fixes #523

New card for single data point:

![Screen Shot 2022-03-10 at 11 18 33 AM](https://user-images.githubusercontent.com/21136804/157728955-a3bba1dc-ad73-4791-a66d-d8a5a33a4884.png)

Previous card:
 
![Screen Shot 2022-03-10 at 11 19 13 AM](https://user-images.githubusercontent.com/21136804/157729040-fa8a45ee-72e5-494d-8b77-400721a0a01c.png)

