### PR TITLE
fix: toggle switch on/off clarity [DES-144]

### DIFF
--- a/src/client/components/common/Toggle/index.tsx
+++ b/src/client/components/common/Toggle/index.tsx
@@ -5,7 +5,6 @@ export interface ToggleButtonProps {
   selected: boolean;
   setSelected: (selected: boolean) => void;
   className?: string;
-  role?: string;
   disabled?: boolean;
   color?: string;
   onClick?: () => void;
@@ -60,7 +59,6 @@ const StyledToggleButton = styled.button<{ selected?: boolean }>`
 export const ToggleButton: FC<ToggleButtonProps> = ({
   selected,
   setSelected,
-  role,
   className,
   disabled,
   color,
@@ -70,7 +68,6 @@ export const ToggleButton: FC<ToggleButtonProps> = ({
   <StyledToggleButton
     className={className}
     selected={selected}
-    role={role}
     disabled={disabled}
     color={color}
     onClick={() => setSelected(!selected)}

--- a/src/client/components/common/Toggle/index.tsx
+++ b/src/client/components/common/Toggle/index.tsx
@@ -5,6 +5,7 @@ export interface ToggleButtonProps {
   selected: boolean;
   setSelected: (selected: boolean) => void;
   className?: string;
+  role?: string;
   disabled?: boolean;
   color?: string;
   onClick?: () => void;
@@ -18,15 +19,14 @@ const ToggleCircle = styled.div`
   position: absolute;
   transition: transform 200ms ease-in-out;
   left: 50%;
-
   transform: translateX(calc(-100% - var(--toggle-offset) / 2));
 `;
 
 const StyledToggleButton = styled.button<{ selected?: boolean }>`
   --toggle-size: 2.6rem;
   --toggle-offset: 0.2rem;
-  --toggle-color: ${({ theme }) => theme.colors.secondary};
-  --toggle-background: ${({ theme }) => theme.colors.primaryVariant};
+  --toggle-color: ${({ theme }) => theme.colors.toggleSwitch.color};
+  --toggle-background: ${({ theme }) => theme.colors.toggleSwitch.background};
 
   display: flex;
   align-items: center;
@@ -45,7 +45,8 @@ const StyledToggleButton = styled.button<{ selected?: boolean }>`
   ${({ selected, theme }) =>
     selected &&
     `
-      --toggle-background: ${theme.colors.primaryVariant};
+      --toggle-color: ${theme.colors.toggleSwitch.selected.color};
+      --toggle-background: ${theme.colors.toggleSwitch.selected.background};
       ${ToggleCircle} {
         transform: translateX(calc(0% + var(--toggle-offset) / 2));
       }
@@ -59,6 +60,7 @@ const StyledToggleButton = styled.button<{ selected?: boolean }>`
 export const ToggleButton: FC<ToggleButtonProps> = ({
   selected,
   setSelected,
+  role,
   className,
   disabled,
   color,
@@ -68,6 +70,7 @@ export const ToggleButton: FC<ToggleButtonProps> = ({
   <StyledToggleButton
     className={className}
     selected={selected}
+    role={role}
     disabled={disabled}
     color={color}
     onClick={() => setSelected(!selected)}

--- a/src/client/themes/classic/index.ts
+++ b/src/client/themes/classic/index.ts
@@ -37,6 +37,16 @@ const classicTheme: DefaultTheme = {
     onSurfaceSH1: '#fff',
     onSurfaceSH1Hover: '#fff',
 
+    toggleSwitch: {
+      background: '#b5b5b5',
+      color: '#E5E5E5',
+
+      selected: {
+        background: '#01E2A0',
+        color: 'white',
+      },
+    },
+
     upTrend: '#01E2A0',
     downTrend: '#EF1E02',
 

--- a/src/client/themes/cyberpunk/index.ts
+++ b/src/client/themes/cyberpunk/index.ts
@@ -35,6 +35,16 @@ const cyberpunkTheme: DefaultTheme = {
     upTrend: '#ADFF00',
     downTrend: '#DE0B3B',
 
+    toggleSwitch: {
+      background: '#b5b5b5',
+      color: '#E5E5E5',
+
+      selected: {
+        background: '#C6E11E',
+        color: 'white',
+      },
+    },
+
     vaultActionButton: {
       background: 'transparent',
       borderColor: '#BB6FA1',

--- a/src/client/themes/cyberpunk/index.ts
+++ b/src/client/themes/cyberpunk/index.ts
@@ -41,7 +41,7 @@ const cyberpunkTheme: DefaultTheme = {
 
       selected: {
         background: '#C6E11E',
-        color: 'white',
+        color: '#fff',
       },
     },
 

--- a/src/client/themes/dark/index.ts
+++ b/src/client/themes/dark/index.ts
@@ -35,6 +35,16 @@ const darkTheme: DefaultTheme = {
     upTrend: '#C6E11E',
     downTrend: '#FF005E',
 
+    toggleSwitch: {
+      background: '#b5b5b5',
+      color: '#E5E5E5',
+
+      selected: {
+        background: '#C6E11E',
+        color: 'white',
+      },
+    },
+
     vaultActionButton: {
       background: 'transparent',
       borderColor: '#6E6E6E',

--- a/src/client/themes/explorer/index.ts
+++ b/src/client/themes/explorer/index.ts
@@ -40,6 +40,16 @@ const explorerTheme: DefaultTheme = {
     onSurfaceSH1: '#eeeeee',
     onSurfaceSH1Hover: '#eeeeee',
 
+    toggleSwitch: {
+      background: '#b5b5b5',
+      color: '#E5E5E5',
+
+      selected: {
+        background: '#C6E11E',
+        color: 'white',
+      },
+    },
+
     upTrend: '#01E2A0',
     downTrend: '#EF1E02',
 

--- a/src/client/themes/light/index.ts
+++ b/src/client/themes/light/index.ts
@@ -35,6 +35,16 @@ const lightTheme: DefaultTheme = {
     upTrend: '#A8C300',
     downTrend: '#FF005E',
 
+    toggleSwitch: {
+      background: '#b5b5b5',
+      color: '#E5E5E5',
+
+      selected: {
+        background: '#A8C300',
+        color: 'white',
+      },
+    },
+
     vaultActionButton: {
       background: 'transparent',
       borderColor: '#000000',

--- a/src/client/themes/styled.d.ts
+++ b/src/client/themes/styled.d.ts
@@ -110,6 +110,16 @@ declare module 'styled-components' {
       upTrend: string;
       downTrend: string;
 
+      toggleSwitch: {
+        background: string,
+        color: string,
+
+        selected: {
+          background: string,
+          color: string,
+        },
+      },
+
       vaultActionButton: {
         background: string;
         borderColor: string;


### PR DESCRIPTION
use success colour in each theme for toggled-on switch background

use grey + nearly-white for off state

![image](https://user-images.githubusercontent.com/80323528/158073661-c1f102c2-4b49-4838-85d8-6c89a75fea82.png)

![image](https://user-images.githubusercontent.com/80323528/158073672-77a16e87-7a84-4494-84be-d867c6bc0d44.png)

![image](https://user-images.githubusercontent.com/80323528/158073825-24705842-a465-475e-80d8-33dc80cc4dd9.png)

