### PR TITLE
refactor: Get all supported tokens directly from the sdk [WEB-1417]

### DIFF
--- a/src/core/services/TokenService.spec.ts
+++ b/src/core/services/TokenService.spec.ts
@@ -1,0 +1,57 @@
+import { createMockToken } from '@src/test';
+
+import { TokenServiceImpl } from './TokenService';
+
+describe('TokenService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSupportedTokens', () => {
+    it('should merge labs with zapper tokens', async () => {
+      const zapperToken = createMockToken({
+        address: '0x001',
+        name: 'Zapper Token 1',
+        supported: { zapper: true },
+      });
+      const labsToken = createMockToken({
+        address: '0x002',
+        name: 'Labs Token',
+        icon: 'labs.icon',
+      });
+      const zapperTokenInLabs = createMockToken({
+        address: '0x002',
+        name: 'Zapper Token 2',
+        icon: 'zapper.icon',
+        supported: { zapper: true },
+      });
+
+      const tokenService = new TokenServiceImpl({
+        yearnSdk: {
+          getInstanceOf: () => ({
+            tokens: {
+              supported: jest.fn().mockResolvedValueOnce([zapperToken, zapperTokenInLabs]),
+            },
+          }),
+        },
+      } as any);
+
+      tokenService.getLabsTokens = jest.fn().mockResolvedValueOnce([labsToken]);
+
+      const actualGetSupportedTokens = await tokenService.getSupportedTokens({ network: 'mainnet' });
+
+      expect(actualGetSupportedTokens.length).toEqual(2);
+      expect(actualGetSupportedTokens).toEqual(
+        expect.arrayContaining([
+          {
+            ...zapperToken,
+            address: '0x001',
+            name: 'Zapper Token 1',
+            supported: { zapper: true },
+          },
+          { ...labsToken, address: '0x002', name: 'Labs Token', icon: 'labs.icon', supported: { zapper: true } },
+        ])
+      );
+    });
+  });
+});

--- a/src/core/services/TokenService.ts
+++ b/src/core/services/TokenService.ts
@@ -1,5 +1,3 @@
-import { unionBy } from 'lodash';
-
 import {
   TokenService,
   YearnSdk,
@@ -51,11 +49,8 @@ export class TokenServiceImpl implements TokenService {
   /* -------------------------------------------------------------------------- */
   public async getSupportedTokens({ network }: GetSupportedTokensProps): Promise<Token[]> {
     const yearn = this.yearnSdk.getInstanceOf(network);
-    const [zapperTokens, vaultsTokens, ironBankTokens]: [Token[], Token[], Token[]] = await Promise.all([
-      yearn.tokens.supported(),
-      yearn.vaults.tokens(),
-      yearn.ironBank.tokens(),
-    ]);
+
+    const supportedTokens = await yearn.tokens.supported();
 
     // We separated this because request is broken outside of this repo so we need to handle it separated
     // so we get the rest of the tokens.
@@ -66,10 +61,7 @@ export class TokenServiceImpl implements TokenService {
       console.log({ error });
     }
 
-    const supportedZapperTokens = zapperTokens.filter((token) => token.supported.zapper);
-    const tokens = unionBy(vaultsTokens, ironBankTokens, 'address');
-    tokens.push(...labsTokens);
-    return getUniqueAndCombine(supportedZapperTokens, tokens, 'address');
+    return getUniqueAndCombine(supportedTokens, labsTokens, 'address');
   }
 
   public async getTokensDynamicData({ network, addresses }: GetTokensDynamicDataProps): Promise<TokenDynamicData[]> {

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/src/test/utils/index.ts
+++ b/src/test/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './token.factory';

--- a/src/test/utils/token.factory.ts
+++ b/src/test/utils/token.factory.ts
@@ -1,0 +1,19 @@
+import { Token } from '@src/core/types';
+
+const DEFAULT_TOKEN: Token = {
+  address: '0x001',
+  decimals: '18',
+  symbol: 'DEAD',
+  name: 'Dead Token',
+  priceUsdc: '0',
+  supported: {},
+  icon: 'icon.svg',
+  metadata: {
+    address: '0x001',
+  },
+};
+
+export const createMockToken = (overwrites: Partial<Token> = {}) => ({
+  ...DEFAULT_TOKEN,
+  ...overwrites,
+});


### PR DESCRIPTION
⚠️ Blocked by https://github.com/yearn/yearn-sdk/pull/249

[WEB-1417](https://linear.app/yearn/issue/WEB-1417/[frontend]-use-refactored-tokeninterfacesupported) (subtask of [WEB-1008](https://linear.app/yearn/issue/WEB-1008/supported-tokens-by-network))

- Get all the supported tokens (Vaults, Iron Bank and Zapper) directly from the SDK;
- Add first spec to the frontend 🎉 