### PR TITLE
fix: pass the onClose prop to ModalTx

### DIFF
--- a/src/client/components/common/TxModal.tsx
+++ b/src/client/components/common/TxModal.tsx
@@ -10,8 +10,14 @@ const StyledModalTx = styled(Modal)`
   height: initial;
 `;
 
-export interface StyledModalTxProps {}
+export interface StyledModalTxProps {
+  onClose?: () => void;
+}
 
-export const ModalTx: FC<StyledModalTxProps> = ({ children, ...props }) => {
-  return <StyledModalTx {...props}>{children}</StyledModalTx>;
+export const ModalTx: FC<StyledModalTxProps> = ({ onClose, children, ...props }) => {
+  return (
+    <StyledModalTx onClose={onClose} {...props}>
+      {children}
+    </StyledModalTx>
+  );
 };

--- a/src/client/containers/Modals/Backscratcher/LockTxModal.tsx
+++ b/src/client/containers/Modals/Backscratcher/LockTxModal.tsx
@@ -11,7 +11,7 @@ export interface BackscratcherLockTxModalProps {
 
 export const BackscratcherLockTxModal: FC<BackscratcherLockTxModalProps> = ({ onClose, ...props }) => {
   return (
-    <StyledBackscratcherLockTxModal {...props}>
+    <StyledBackscratcherLockTxModal onClose={onClose} {...props}>
       <BackscratcherLockTx onClose={onClose} />
     </StyledBackscratcherLockTxModal>
   );


### PR DESCRIPTION
Suggestion for #530

assuming that the `onClose` function could be called either when
- the modal is closed
- `onTransactionCompletedDismissed` is called from the transaction

I have added the onClose prop to the wrapper modal as well. Let me know if this is not the intended behavior.

And also I would like to note that a number of modals (e.g. Backscractchers) share this same structure, so if we could work with this I may add this to the other TxModals as well
