### PR TITLE
fix: Get metadata overrides for `yvBoost` from `vaults.getDynamic()`

### DIFF
--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -145,7 +145,7 @@ export class LabServiceImpl implements LabService {
       const yvBoostData = vaultsResponse.data.find(({ address }: { address: string }) => address === YVBOOST);
 
       // TODO We could use the data from `yvBoostVaultDynamic`
-      if (!yvBoostData || !yvBoostVaultDynamic) {
+      if (!yvBoostData) {
         throw new Error(`yvBoost vault not found on ${YEARN_API} response`);
       }
 
@@ -154,17 +154,8 @@ export class LabServiceImpl implements LabService {
       }
 
       const { address, decimals, name, symbol, token, version } = yvBoostData;
+
       const { underlyingTokenBalance } = yvBoostVaultDynamic;
-
-      const amount = underlyingTokenBalance.amount.toString();
-
-      const yveCrvPrice = pricesResponse.data['vecrv-dao-yvault']['usd'];
-
-      // This amount usdc is slightly different from the one that comes from `underlyingTokenBalance`
-      const amountUsdc = toBN(normalizeAmount(amount, decimals))
-        .times(yveCrvPrice)
-        .times(10 ** USDC_DECIMALS)
-        .toFixed(0);
 
       yvBoostLab = {
         address,
@@ -175,10 +166,7 @@ export class LabServiceImpl implements LabService {
         symbol,
         decimals: decimals.toString(),
         tokenId: token.address,
-        underlyingTokenBalance: {
-          amount,
-          amountUsdc,
-        },
+        underlyingTokenBalance,
         metadata: {
           ...yvBoostVaultDynamic.metadata,
           displayIcon: `${ASSET_URL}${address}/logo-128.png`,


### PR DESCRIPTION
Closes https://github.com/yearn/yearn-finance-v3/issues/524

Get metadata overrides for `yvBoost` from `vaults.getDynamic()`, the `displayIcon` is overwritten in order to be the yvToken icon itself.

<img width="1170" alt="yearn_finance" src="https://user-images.githubusercontent.com/78794805/160202985-ebfca3cd-fc09-428e-8d4a-7e94d0b776a2.png">