### PR TITLE
fix: switch network prompt only for metamask wallet

### DIFF
--- a/src/core/frameworks/blocknative/Onboard.ts
+++ b/src/core/frameworks/blocknative/Onboard.ts
@@ -144,7 +144,7 @@ export class BlocknativeWalletImpl implements Wallet {
       this.onboard.config({ networkId });
     }
 
-    if (this.onboard && this.name === 'MetaMask') {
+    if (this.onboard && this.isMetaMask()) {
       try {
         await this.getState()?.wallet.provider.request({
           method: 'wallet_switchEthereumChain',
@@ -202,5 +202,9 @@ export class BlocknativeWalletImpl implements Wallet {
     } catch (error) {
       return false;
     }
+  }
+
+  private isMetaMask(): boolean {
+    return this.name?.toUpperCase() === 'MetaMask'.toUpperCase();
   }
 }

--- a/src/core/frameworks/blocknative/Onboard.ts
+++ b/src/core/frameworks/blocknative/Onboard.ts
@@ -139,8 +139,12 @@ export class BlocknativeWalletImpl implements Wallet {
     const { NETWORK_SETTINGS } = getConfig();
     const networkSettings = NETWORK_SETTINGS[network];
     const networkId = networkSettings.networkId;
+
     if (this.onboard) {
       this.onboard.config({ networkId });
+    }
+
+    if (this.onboard && this.name === 'MetaMask') {
       try {
         await this.getState()?.wallet.provider.request({
           method: 'wallet_switchEthereumChain',
@@ -168,10 +172,11 @@ export class BlocknativeWalletImpl implements Wallet {
           }
         }
         console.error(error);
+        return false;
       }
     }
 
-    return false;
+    return true;
   }
 
   public async addToken(


### PR DESCRIPTION
- Fix issue with wallets that dont implement same interface as metamask for switching/adding networks. Will just prompt network change when using Metamask wallet.

Fixes #532 