### PR TITLE
fix: console errors on open modal

### DIFF
--- a/src/client/components/app/Transactions/Transaction.tsx
+++ b/src/client/components/app/Transactions/Transaction.tsx
@@ -109,7 +109,7 @@ export const Transaction: FC<TransactionProps> = (props) => {
 
   if (transactionCompleted) {
     return (
-      <StyledTransaction onClose={onClose} header={transactionLabel} {...props}>
+      <StyledTransaction onClose={onClose} header={transactionLabel}>
         <TxStatus transactionCompletedLabel={transactionCompletedLabel} exit={onTransactionCompletedDismissed} />
       </StyledTransaction>
     );
@@ -130,7 +130,7 @@ export const Transaction: FC<TransactionProps> = (props) => {
   }`;
 
   return (
-    <StyledTransaction onClose={onClose} header={transactionLabel} {...props}>
+    <StyledTransaction onClose={onClose} header={transactionLabel}>
       <TxTokenInput
         headerText={sourceHeader}
         inputText={sourceInputText}

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -265,7 +265,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
 
   return (
     <StyledTxTokenInput {...props}>
-      {headerText && <Header>{headerText}</Header>}
+      <>{headerText && <Header>{headerText}</Header>}</>
       {openedSearch && (
         <CSSTransition in={openedSearch} appear={true} timeout={scaleTransitionTime} classNames="scale">
           <StyledSearchList
@@ -278,40 +278,42 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
         </CSSTransition>
       )}
 
-      <TokenInfo>
-        <TokenSelector onClick={listItems?.length > 1 ? openSearchList : undefined}>
-          <TokenIconContainer>
-            <TokenIcon icon={selectedItem.icon} symbol={selectedItem.label} size="big" />
-            {listItems?.length > 1 && <TokenListIcon Component={ChevronRightIcon} />}
-          </TokenIconContainer>
-          <TokenName>{selectedItem.label}</TokenName>
-        </TokenSelector>
+      <>
+        <TokenInfo>
+          <TokenSelector onClick={listItems?.length > 1 ? openSearchList : undefined}>
+            <TokenIconContainer>
+              <TokenIcon icon={selectedItem.icon} symbol={selectedItem.label} size="big" />
+              {listItems?.length > 1 && <TokenListIcon Component={ChevronRightIcon} />}
+            </TokenIconContainer>
+            <TokenName>{selectedItem.label}</TokenName>
+          </TokenSelector>
 
-        <TokenData>
-          <AmountTitle>{inputText || t('components.transaction.token-input.balance')}</AmountTitle>
-          <StyledAmountInput
-            value={amount}
-            onChange={onAmountChange ? (e) => onAmountChange(e.target.value) : undefined}
-            placeholder={loading ? loadingText : '00000000.00'}
-            readOnly={readOnly}
-            error={inputError}
-            type="number"
-          />
-          <TokenExtras>
-            {amountValue && <StyledText>≈ {formatUsd(!loading && !inputError ? amountValue : '0')}</StyledText>}
-            {maxAmount && (
-              <StyledButton onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined}>
-                {maxLabel}
-              </StyledButton>
-            )}
-            {yieldPercent && (
-              <StyledText>
-                {t('components.transaction.token-input.yield')} <ContrastText>{yieldPercent}</ContrastText>
-              </StyledText>
-            )}
-          </TokenExtras>
-        </TokenData>
-      </TokenInfo>
+          <TokenData>
+            <AmountTitle>{inputText || t('components.transaction.token-input.balance')}</AmountTitle>
+            <StyledAmountInput
+              value={amount}
+              onChange={onAmountChange ? (e) => onAmountChange(e.target.value) : undefined}
+              placeholder={loading ? loadingText : '00000000.00'}
+              readOnly={readOnly}
+              error={inputError}
+              type="number"
+            />
+            <TokenExtras>
+              {amountValue && <StyledText>≈ {formatUsd(!loading && !inputError ? amountValue : '0')}</StyledText>}
+              {maxAmount && (
+                <StyledButton onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined}>
+                  {maxLabel}
+                </StyledButton>
+              )}
+              {yieldPercent && (
+                <StyledText>
+                  {t('components.transaction.token-input.yield')} <ContrastText>{yieldPercent}</ContrastText>
+                </StyledText>
+              )}
+            </TokenExtras>
+          </TokenData>
+        </TokenInfo>
+      </>
     </StyledTxTokenInput>
   );
 };

--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -409,7 +409,7 @@ export const VaultDetailPanels = ({
 
               <OverviewStrategies>
                 {strategies.map((strategy) => (
-                  <OverviewInfo variant="surface" cardSize="micro">
+                  <OverviewInfo variant="surface" cardSize="micro" key={strategy.address}>
                     <StyledCardHeader subHeader={strategy.name} />
                     <StyledCardContent>
                       <Markdown>{strategy.description}</Markdown>


### PR DESCRIPTION
Added React Fragments to several JSX Elements as a TransitionGroup expects its immediate children to be of type Transition. It will pass in `onExit` props to all of those child nodes. The errors appear as those properties are not valid to the child nodes. If we wrap the components in a Transition or CSSTransition or a React Fragment, those warnings will go away.

Fixes #508 