### PR TITLE
docs: add windows dev env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Code style follows prettier conventions (`yarn prettier`). Commit messages follo
 ```
 yarn dev
 ```
+or for Windows:
+```
+yarn dev-win
+```
 
 - To enable Dev Mode set `REACT_APP_ALLOW_DEV_MODE=true` in your `.env`
 - Wallet Address Override can be activated by navigating to Settings in the app and clicking `Enable Dev Mode`


### PR DESCRIPTION
`yarn dev` doesn't work on Windows, `yarn dev-win` does :)