### PR TITLE
test: `BigNumber` formatters

### DIFF
--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -1,0 +1,62 @@
+import BigNumber from 'bignumber.js';
+
+import { toBN, toUnit, toWei } from './format';
+
+describe('Fromatters', () => {
+  describe('toBN', () => {
+    it('should convert `string` to `BigNumber`', () => {
+      const actual = toBN('123');
+
+      expect(actual).toEqual(new BigNumber(123));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it('should convert `number` to `BigNumber`', () => {
+      const actual = toBN(123);
+
+      expect(actual).toEqual(new BigNumber(123));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it.each`
+      falsyArgument
+      ${false}
+      ${0}
+      ${''}
+      ${null}
+      ${undefined}
+      ${NaN}
+    `(`should return \`BigNumber(0)\` when given "$falsyArgument"`, ({ falsyArgument }) => {
+      const actual = toBN(falsyArgument);
+
+      expect(actual).toEqual(new BigNumber(0));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it('should return `BigNumber(0)` when given a falsy argument', () => {
+      const actualWithEmptyString = toBN('');
+      const actualWithUndefined = toBN();
+
+      expect(actualWithEmptyString).toEqual(new BigNumber(0));
+      expect(actualWithEmptyString instanceof BigNumber).toBeTruthy();
+      expect(actualWithUndefined).toEqual(new BigNumber(0));
+      expect(actualWithUndefined instanceof BigNumber).toBeTruthy();
+    });
+  });
+
+  describe('toWei', () => {
+    it('should convert amount in Unit to Wei', () => {
+      const actual = toWei('123', 18);
+
+      expect(actual).toEqual('123000000000000000000');
+    });
+  });
+
+  describe('toUnit', () => {
+    it('should convert amount in Wei to Unit', () => {
+      const actual = toUnit('123000000000000000000', 18);
+
+      expect(actual).toEqual('123');
+    });
+  });
+});

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 
 import { toBN, toUnit, toWei } from './format';
 
-describe('Fromatters', () => {
+describe('Formatters', () => {
   describe('toBN', () => {
     it('should convert `string` to `BigNumber`', () => {
       const actual = toBN('123');

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -24,8 +24,7 @@ const FORMAT = {
 /* -------------------------------------------------------------------------- */
 
 export const toBN = (amount?: Amount | number): BigNumber => {
-  if (!amount || amount === '') amount = '0';
-  return new BigNumber(amount);
+  return new BigNumber(amount || 0);
 };
 
 export const toWei = (amount: Unit, decimals: number): Wei => {


### PR DESCRIPTION
Since I've added the same formatters in the SDK (https://github.com/yearn/yearn-sdk/pull/267), thought of reusing the tests in here with the added benefit of getting testing the formatters started.

Tests the following utility functions that work with `BigNumber`

* `toBN()`
* `toWei()`
* `toUnit()`