### PR TITLE
fix: filter yvboost from supported vaults

### DIFF
--- a/src/core/services/VaultService.ts
+++ b/src/core/services/VaultService.ts
@@ -58,9 +58,10 @@ export class VaultServiceImpl implements VaultService {
   /* -------------------------------------------------------------------------- */
 
   public async getSupportedVaults({ network, addresses }: GetSupportedVaultsProps): Promise<Vault[]> {
+    const { YVBOOST } = this.config.CONTRACT_ADDRESSES;
     const yearn = this.yearnSdk.getInstanceOf(network);
     const vaults = await yearn.vaults.get(addresses);
-    return vaults;
+    return vaults.filter(({ address }) => address !== YVBOOST);
   }
 
   public async getVaultsDynamicData({ network, addresses }: GetVaultsDynamicDataProps): Promise<VaultDynamic[]> {


### PR DESCRIPTION
- Remove yvBoost from supported vaults since its displayed on Labs section.