### PR TITLE
fix: yvboost dynamic data

### DIFF
--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -141,6 +141,7 @@ export class LabServiceImpl implements LabService {
     // **************** YVBOOST ****************
     let yvBoostLab: Lab | undefined;
     try {
+      // TODO: Use yearn.vaults.getDynamic when issue solved in SDK
       const [yvBoostVaultDynamic] = await yearn.vaults.get([YVBOOST]);
       const yvBoostData = vaultsResponse.data.find(({ address }: { address: string }) => address === YVBOOST);
 

--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -141,7 +141,7 @@ export class LabServiceImpl implements LabService {
     // **************** YVBOOST ****************
     let yvBoostLab: Lab | undefined;
     try {
-      const [yvBoostVaultDynamic] = await yearn.vaults.getDynamic([YVBOOST]);
+      const [yvBoostVaultDynamic] = await yearn.vaults.get([YVBOOST]);
       const yvBoostData = vaultsResponse.data.find(({ address }: { address: string }) => address === YVBOOST);
 
       // TODO We could use the data from `yvBoostVaultDynamic`


### PR DESCRIPTION
- Use `yearn.vaults.get` in favor of `yearn.vaults.getDynamic` temporarily while issue solved on sdk/cache