### PR TITLE
fix: lock modal missing onClose prop on transaction [WEB-1442]

### DIFF
--- a/src/client/components/app/Transactions/Backscratcher/LockTx.tsx
+++ b/src/client/components/app/Transactions/Backscratcher/LockTx.tsx
@@ -172,6 +172,7 @@ export const BackscratcherLockTx: FC<BackscratcherLockTxProps> = ({ onClose, chi
       targetStatus={{ error: targetError }}
       actions={txActions}
       sourceStatus={{ error: sourceError }}
+      onClose={onClose}
     />
   );
 };


### PR DESCRIPTION
We forgot the onClose prop on the lock modal.
Now:
<img width="453" alt="image" src="https://user-images.githubusercontent.com/78362532/161961952-ef7d1dab-b852-4e6d-9c3e-31dc0b3f830a.png">
