### PR TITLE
feat: re-enable fantom earnings summary data

### DIFF
--- a/src/config/constants/index.ts
+++ b/src/config/constants/index.ts
@@ -57,7 +57,7 @@ const NETWORK_SETTINGS: NetworkSettings = {
     zapsEnabled: false,
     labsEnabled: false,
     ironBankEnabled: true,
-    earningsEnabled: false,
+    earningsEnabled: true,
     notifyEnabled: false,
     blockExplorerUrl: 'https://ftmscan.com',
     txConfirmations: 10,


### PR DESCRIPTION
- Re-enable Fantom earnings summary data since subgraph appears to be fixed