### PR TITLE
fix: eth deposit modal

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,6 +1,9 @@
 import { ethers } from 'ethers';
 import { keyBy, merge, values, orderBy, toNumber, isString } from 'lodash';
 
+import { createToken } from '@src/core/store/modules/tokens/tokens.selectors';
+import { Balance, Token, TokenView } from '@src/core/types';
+
 export const isValidAddress = (address: string): boolean => {
   try {
     ethers.utils.getAddress(address);
@@ -65,3 +68,14 @@ export const inLedgerIframe = () => {
 };
 
 export const isCustomApyType = (apyType: string) => apyType === 'new' || apyType === 'n/a' || apyType === 'override';
+
+export const createPlaceholderToken = (tokenData: Token): TokenView => {
+  const userTokenData: Balance = {
+    address: tokenData.address,
+    token: tokenData,
+    priceUsdc: tokenData.priceUsdc,
+    balance: '0',
+    balanceUsdc: '0',
+  };
+  return createToken({ tokenData, userTokenData, allowancesMap: {} });
+};


### PR DESCRIPTION
Fixes #571 

Added `createPlaceholderToken` in `misc.ts` to create placeholder tokens.

If the user has no ETH in their wallet, the placeholder token will be used provided the selected sell token is the native currency.