### PR TITLE
fix: `useAllowance` error

### DIFF
--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -72,7 +72,7 @@ export const DepositTx: FC<DepositTxProps> = ({
     : userTokens;
   const sellTokensOptionsMap = keyBy(sellTokensOptions, 'address');
   const selectedSellToken = sellTokensOptionsMap[selectedSellTokenAddress ?? ''];
-  const [tokenAllowance, isLoadingTokenAllowance, tokenAllowanceErrors] = useAllowance({
+  const [tokenAllowance, isLoadingTokenAllowance, tokenAllowanceError] = useAllowance({
     tokenAddress: selectedSellTokenAddress,
     vaultAddress: selectedVault?.address,
   });
@@ -199,7 +199,7 @@ export const DepositTx: FC<DepositTxProps> = ({
       actionsStatus.approve.error ||
       actionsStatus.deposit.error ||
       slippageError ||
-      tokenAllowanceErrors,
+      tokenAllowanceError,
     loading: expectedTxOutcomeStatus.loading || isDebouncePending || isLoadingTokenAllowance,
   };
 

--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -67,7 +67,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
     : userTokens;
   const sellTokensOptionsMap = keyBy(sellTokensOptions, 'address');
   const selectedSellToken = sellTokensOptionsMap[selectedSellTokenAddress ?? ''];
-  const [tokenAllowance, isLoadingTokenAllowance, tokenAllowanceErrors] = useAllowance({
+  const [tokenAllowance, isLoadingTokenAllowance, tokenAllowanceError] = useAllowance({
     tokenAddress: selectedSellTokenAddress,
     vaultAddress: selectedLab?.address,
     isLab: true,
@@ -153,7 +153,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
       actionsStatus.approveDeposit.error ||
       actionsStatus.deposit.error ||
       slippageError ||
-      tokenAllowanceErrors,
+      tokenAllowanceError,
     loading: expectedTxOutcomeStatus.loading || isDebouncePending || isLoadingTokenAllowance,
   };
 

--- a/src/client/hooks/useAllowance.ts
+++ b/src/client/hooks/useAllowance.ts
@@ -13,6 +13,15 @@ interface useAllowanceProps {
   vaultAddress?: string;
   isLab?: boolean;
 }
+
+type AllowanceError = {
+  name?: string;
+  message?: string;
+  stack?: string;
+};
+
+const isError = (err: unknown): err is Error => err instanceof Error;
+
 export function useAllowance({
   tokenAddress,
   vaultAddress,
@@ -20,7 +29,7 @@ export function useAllowance({
 }: useAllowanceProps): [TokenAllowance | undefined, boolean, string?] {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<TokenAllowance | undefined>(undefined);
-  const [error, setError] = useState<any | undefined>(undefined);
+  const [error, setError] = useState<AllowanceError>();
   const prevVault = usePrevious(vaultAddress);
   const prevTokenAddress = usePrevious(tokenAddress);
   const dispatch = useAppDispatch();
@@ -49,7 +58,11 @@ export function useAllowance({
           setResult(result);
           setError(undefined);
         } catch (e) {
-          setError(e);
+          if (isError(e) && e.message) {
+            setError(e);
+          } else {
+            setError({ message: JSON.stringify(e) });
+          }
         }
       }
       setIsLoading(false);
@@ -68,5 +81,5 @@ export function useAllowance({
     }
   }, [vaultAddress, prevVault, prevTokenAddress, tokenAddress, isLoading, result, error]);
 
-  return [result, isLoading, error];
+  return [result, isLoading, error?.message];
 }


### PR DESCRIPTION
A bit flaky to reproduce, but I think the `useAllowance` hook was returning an error object rather than a string.

**Issue**

The vault details page was getting "Objects are not valid as a React child (found: object with keys {name, message, stack}). If you meant to render a collection of children, use an array instead."

