### PR TITLE
fix: order labs by highest apy

### DIFF
--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -306,14 +306,14 @@ export const Labs = () => {
           {currentNetworkSettings.labsEnabled && (
             <StyledRecommendationsCard
               header={t('components.recommendations.header')}
-              items={recommendations
-                .sort((a, b) => Number(b.apyData) - Number(a.apyData))
-                .map(({ displayName, apyData, displayIcon }) => ({
-                  icon: displayIcon,
-                  name: displayName,
-                  info: formatPercent(apyData, 2),
-                  infoDetail: 'EYY',
-                }))}
+              items={recommendations.map(({ address, displayName, apyData, displayIcon }) => ({
+                // header: 'Special Token',
+                icon: displayIcon,
+                name: displayName,
+                info: formatPercent(apyData, 2),
+                infoDetail: 'EYY',
+                // onAction: () => history.push(`/vault/${address}`),
+              }))}
             />
           )}
 

--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -306,14 +306,14 @@ export const Labs = () => {
           {currentNetworkSettings.labsEnabled && (
             <StyledRecommendationsCard
               header={t('components.recommendations.header')}
-              items={recommendations.map(({ address, displayName, apyData, displayIcon }) => ({
-                // header: 'Special Token',
-                icon: displayIcon,
-                name: displayName,
-                info: formatPercent(apyData, 2),
-                infoDetail: 'EYY',
-                // onAction: () => history.push(`/vault/${address}`),
-              }))}
+              items={recommendations
+                .sort((a, b) => Number(b.apyData) - Number(a.apyData))
+                .map(({ displayName, apyData, displayIcon }) => ({
+                  icon: displayIcon,
+                  name: displayName,
+                  info: formatPercent(apyData, 2),
+                  infoDetail: 'EYY',
+                }))}
             />
           )}
 

--- a/src/core/store/modules/labs/labs.selectors.ts
+++ b/src/core/store/modules/labs/labs.selectors.ts
@@ -150,7 +150,7 @@ const selectLabsOpportunities = createSelector([selectLabs], (labs) => {
 
 const selectRecommendations = createSelector([selectLabs], (labs) => {
   // TODO criteria
-  return labs.slice(0, 3);
+  return labs.slice(0, 3).sort((a, b) => Number(b.apyData) - Number(a.apyData));
 });
 
 const selectSelectedLab = createSelector([selectLabs, selectSelectedLabAddress], (labs, selectedLabAddress) => {


### PR DESCRIPTION
## Description

- Sorts the labs vaults by highest APY when displaying

## Related Issue

Fixes #615

## How Has This Been Tested?

Tested locally by checking the labs page

## Screenshots (if appropriate):

![Screen Shot 2022-04-27 at 11 20 34 PM](https://user-images.githubusercontent.com/21136804/165681760-c57ff47d-36bf-4d65-bcd2-c48f42a7922f.png)

