### PR TITLE
fix: Readable vault error message

### DIFF
--- a/src/client/hooks/useAllowance.ts
+++ b/src/client/hooks/useAllowance.ts
@@ -20,7 +20,12 @@ type AllowanceError = {
   stack?: string;
 };
 
-const isError = (err: unknown): err is Error => err instanceof Error;
+const isError = (err: unknown): err is AllowanceError => {
+  if (err instanceof Error && err.message) return true;
+
+  const errObject = err as Record<string, unknown>;
+  return !!errObject && errObject.hasOwnProperty('message') && typeof errObject.message === 'string';
+};
 
 export function useAllowance({
   tokenAddress,
@@ -58,7 +63,7 @@ export function useAllowance({
           setResult(result);
           setError(undefined);
         } catch (e) {
-          if (isError(e) && e.message) {
+          if (isError(e)) {
             setError(e);
           } else {
             setError({ message: JSON.stringify(e) });


### PR DESCRIPTION
## Description

- Displays readable vault error message.
- `isError` is returning `false` as error object is not an instance of `Error` but contains the correct properties.
- Additional duck typing checks added to ensure object closely resembles an `Error` instance.

## Related Issue

Fixes #600 

## How Has This Been Tested?

Tested locally and checking the displayed vault error message

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/83656073/165794352-deb62336-f478-4bd0-8d2e-4c5af2073de1.png)

