### PR TITLE
fix: portfolio wallet deposit modal vault select

### DIFF
--- a/src/client/containers/Modals/DepositTxModal/index.tsx
+++ b/src/client/containers/Modals/DepositTxModal/index.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
 
 import { useAppTranslation } from '@hooks';
 import { ModalTx } from '@components/common';
@@ -9,28 +8,24 @@ import { DepositTx } from '@components/app';
 const StyledDepositTxModal = styled(ModalTx)``;
 export interface DepositTxModalProps {
   onClose: () => void;
+  modalProps?: {
+    allowTokenSelect: boolean;
+    allowVaultSelect: boolean;
+  };
 }
 
-export const DepositTxModal: FC<DepositTxModalProps> = ({ onClose, ...props }) => {
+export const DepositTxModal: FC<DepositTxModalProps> = ({
+  onClose,
+  modalProps = { allowTokenSelect: true, allowVaultSelect: false },
+  ...props
+}) => {
   const { t } = useAppTranslation('common');
-
-  const location = useLocation();
-
-  const path = location.pathname.toLowerCase().split('/')[1];
-  let allowTokenSelect = true;
-  let allowVaultSelect = false;
-
-  if (path === 'wallet') {
-    allowTokenSelect = false;
-    allowVaultSelect = true;
-  }
-
   return (
     <StyledDepositTxModal {...props}>
       <DepositTx
         header={t('components.transaction.deposit')}
-        allowTokenSelect={allowTokenSelect}
-        allowVaultSelect={allowVaultSelect}
+        allowTokenSelect={modalProps.allowTokenSelect}
+        allowVaultSelect={modalProps.allowVaultSelect}
         onClose={onClose}
       />
     </StyledDepositTxModal>

--- a/src/client/containers/Modals/index.tsx
+++ b/src/client/containers/Modals/index.tsx
@@ -127,7 +127,7 @@ export const Modals = () => {
 
       {activeModal === 'depositTx' && (
         <CSSTransition key={'depositTx'} timeout={modalTimeout} classNames="slideBottom">
-          <DepositTxModal onClose={closeModal} />
+          <DepositTxModal modalProps={modalProps} onClose={closeModal} />
         </CSSTransition>
       )}
 

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -141,7 +141,12 @@ export const Portfolio = () => {
     switch (action) {
       case 'invest':
         dispatch(TokensActions.setSelectedTokenAddress({ tokenAddress }));
-        dispatch(ModalsActions.openModal({ modalName: 'depositTx' }));
+        dispatch(
+          ModalsActions.openModal({
+            modalName: 'depositTx',
+            modalProps: { allowTokenSelect: false, allowVaultSelect: true },
+          })
+        );
         break;
       default:
         break;


### PR DESCRIPTION
## Description

* Currently, the transaction deposit modal expects the URL path to be `/wallet` when it sets the `allowVaultSelect` parameter `true`, this doesn't happen right now since the new page URL path is `/portfolio`
* I updated the code to pass in props to the modal instead of reading the path, so that this is more explicit and shouldn't happen again if we ever change the page URL path later down the road

## Related Issue

Fixes #626 

## Motivation and Context

Now users can select a vault to zap into again instead of just the default

## How Has This Been Tested?

Manually tested on portfolio wallet page with different tokens. Also tested the vault page and confirmed that functionality is still the same there (can change token but cannot change vault to deposit into).

## Screenshots (if appropriate):

![Screen Shot 2022-05-03 at 5 11 08 PM](https://user-images.githubusercontent.com/21136804/166587794-1db629cb-6ac8-4c5c-8e66-69d82bd6f43f.png)

![Screen Shot 2022-05-03 at 5 13 19 PM](https://user-images.githubusercontent.com/21136804/166587829-9a01d99b-8822-4b34-9ba1-9bda118a9bac.png)

