### PR TITLE
fix: deposit token allowance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yearn-finance-v3",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "start": "craco start",

--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -56,7 +56,7 @@ export const DepositTx: FC<DepositTxProps> = ({
   const [isFetchingAllowance, setIsFetchingAllowance] = useState(false);
   const currentNetwork = useAppSelector(NetworkSelectors.selectCurrentNetwork);
   const walletNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
-  const walletIsConnected = useAppSelector(WalletSelectors.selectWalletIsConnected);
+  const isWalletConnected = useAppSelector(WalletSelectors.selectWalletIsConnected);
   const currentNetworkSettings = NETWORK_SETTINGS[currentNetwork];
   const vaults = useAppSelector(VaultsSelectors.selectLiveVaults);
   const selectedVault = useAppSelector(VaultsSelectors.selectSelectedVault);
@@ -107,7 +107,7 @@ export const DepositTx: FC<DepositTxProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!selectedVault || !selectedSellTokenAddress || !walletIsConnected) return;
+    if (!selectedVault || !selectedSellTokenAddress || !isWalletConnected) return;
     const fetchAllowance = async () => {
       setIsFetchingAllowance(true);
       await dispatch(
@@ -119,7 +119,7 @@ export const DepositTx: FC<DepositTxProps> = ({
       setIsFetchingAllowance(false);
     };
     fetchAllowance();
-  }, [selectedSellTokenAddress, selectedVault?.address, walletIsConnected]);
+  }, [selectedSellTokenAddress, selectedVault?.address, isWalletConnected]);
 
   useEffect(() => {
     if (!selectedVault) return;

--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -111,7 +111,7 @@ export const DepositTx: FC<DepositTxProps> = ({
     const fetchAllowance = async () => {
       setIsFetchingAllowance(true);
       await dispatch(
-        VaultsActions.getVaultAllowance({
+        VaultsActions.getDepositAllowance({
           vaultAddress: selectedVault.address,
           tokenAddress: selectedSellTokenAddress,
         })

--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -50,7 +50,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
   const [isFetchingAllowance, setIsFetchingAllowance] = useState(false);
   const currentNetwork = useAppSelector(NetworkSelectors.selectCurrentNetwork);
   const walletNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
-  const walletIsConnected = useAppSelector(WalletSelectors.selectWalletIsConnected);
+  const isWalletConnected = useAppSelector(WalletSelectors.selectWalletIsConnected);
   const currentNetworkSettings = NETWORK_SETTINGS[currentNetwork];
   const selectedLab = useAppSelector(LabsSelectors.selectSelectedLab);
   const selectedSellTokenAddress = useAppSelector(TokensSelectors.selectSelectedTokenAddress);
@@ -82,7 +82,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
   }, []);
 
   useEffect(() => {
-    if (!selectedLab || !selectedSellTokenAddress || !walletIsConnected) return;
+    if (!selectedLab || !selectedSellTokenAddress || !isWalletConnected) return;
     const fetchAllowance = async () => {
       setIsFetchingAllowance(true);
       await dispatch(
@@ -94,7 +94,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
       setIsFetchingAllowance(false);
     };
     fetchAllowance();
-  }, [selectedSellTokenAddress, selectedLab?.address, walletIsConnected]);
+  }, [selectedSellTokenAddress, selectedLab?.address, isWalletConnected]);
 
   useEffect(() => {
     if (!selectedLab) return;

--- a/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
+++ b/src/client/components/app/Transactions/Labs/LabDepositTx.tsx
@@ -86,7 +86,7 @@ export const LabDepositTx: FC<LabDepositTxProps> = ({ onClose }) => {
     const fetchAllowance = async () => {
       setIsFetchingAllowance(true);
       await dispatch(
-        LabsActions.getLabAllowance({
+        LabsActions.getDepositAllowance({
           labAddress: selectedLab.address,
           tokenAddress: selectedSellTokenAddress,
         })

--- a/src/client/hooks/useAllowance.ts
+++ b/src/client/hooks/useAllowance.ts
@@ -46,14 +46,14 @@ export function useAllowance({
           let promiseResult;
           if (isLab) {
             promiseResult = await dispatch(
-              LabsActions.getLabAllowance({
+              LabsActions.getDepositAllowance({
                 labAddress: vaultAddress,
                 tokenAddress,
               })
             );
           } else {
             promiseResult = await dispatch(
-              VaultsActions.getVaultAllowance({
+              VaultsActions.getDepositAllowance({
                 vaultAddress,
                 tokenAddress,
               })

--- a/src/client/hooks/useAllowance.ts
+++ b/src/client/hooks/useAllowance.ts
@@ -47,7 +47,7 @@ export function useAllowance({
           if (isLab) {
             promiseResult = await dispatch(
               LabsActions.getLabAllowance({
-                vaultAddress,
+                labAddress: vaultAddress,
                 tokenAddress,
               })
             );

--- a/src/core/services/VaultService.ts
+++ b/src/core/services/VaultService.ts
@@ -25,7 +25,7 @@ import {
   Config,
   ApproveDepositProps,
   ApproveZapOutProps,
-  GetVaultAllowanceProps,
+  GetDepositAllowanceProps,
   TokenAllowance,
 } from '@types';
 
@@ -277,12 +277,12 @@ export class VaultServiceImpl implements VaultService {
     return yearn.vaults.approveWithdraw(accountAddress, vaultAddress, tokenAddress, amount);
   }
 
-  public async getVaultAllowance({
+  public async getDepositAllowance({
     network,
     vaultAddress,
     tokenAddress,
     accountAddress,
-  }: GetVaultAllowanceProps): Promise<TokenAllowance> {
+  }: GetDepositAllowanceProps): Promise<TokenAllowance> {
     const yearn = this.yearnSdk.getInstanceOf(network);
     const allowance = await yearn.vaults.getDepositAllowance(accountAddress, vaultAddress, tokenAddress);
 

--- a/src/core/store/modules/labs/labs.actions.ts
+++ b/src/core/store/modules/labs/labs.actions.ts
@@ -164,7 +164,7 @@ const approveDeposit = createAsyncThunk<{ amount: string; spenderAddress: string
 
     await transactionService.handleTransaction({ tx, network: network.current });
 
-    const { spender } = await vaultService.getVaultAllowance({
+    const { spender } = await vaultService.getDepositAllowance({
       network: network.current,
       vaultAddress: labAddress,
       tokenAddress,
@@ -178,14 +178,14 @@ const approveDeposit = createAsyncThunk<{ amount: string; spenderAddress: string
   }
 );
 
-const getLabAllowance = createAsyncThunk<
+const getDepositAllowance = createAsyncThunk<
   TokenAllowance,
   {
     tokenAddress: string;
     labAddress: string;
   },
   ThunkAPI
->('labs/getLabAllowance', async ({ labAddress, tokenAddress }, { extra, getState, dispatch }) => {
+>('labs/getDepositAllowance', async ({ labAddress, tokenAddress }, { extra, getState, dispatch }) => {
   const {
     services: { vaultService },
   } = extra;
@@ -194,7 +194,7 @@ const getLabAllowance = createAsyncThunk<
 
   if (!userAddress) throw new Error('WALLET NOT CONNECTED');
 
-  const tokenAllowance = await vaultService.getVaultAllowance({
+  const tokenAllowance = await vaultService.getDepositAllowance({
     network: network.current,
     vaultAddress: labAddress,
     tokenAddress,
@@ -783,7 +783,7 @@ export const LabsActions = {
   clearSelectedLabAndStatus,
   clearLabStatus,
   clearUserData,
-  getLabAllowance,
+  getDepositAllowance,
   yvBoost: {
     yvBoostApproveDeposit,
     yvBoostDeposit,

--- a/src/core/store/modules/tokens/tokens.actions.ts
+++ b/src/core/store/modules/tokens/tokens.actions.ts
@@ -8,6 +8,9 @@ import { TokenDynamicData, Token, Balance, Integer } from '@types';
 /* -------------------------------------------------------------------------- */
 
 const setSelectedTokenAddress = createAction<{ tokenAddress?: string }>('tokens/setSelectedTokenAddress');
+const setTokenAllowance = createAction<{ tokenAddress: string; spenderAddress: string; allowance: Integer }>(
+  'tokens/setTokenAllowance'
+);
 
 /* -------------------------------------------------------------------------- */
 /*                                 Clear State                                */
@@ -149,6 +152,7 @@ const initSubscriptions = createAsyncThunk<void, void, ThunkAPI>(
 
 export const TokensActions = {
   setSelectedTokenAddress,
+  setTokenAllowance,
   getTokens,
   getTokensDynamicData,
   getUserTokens,

--- a/src/core/store/modules/tokens/tokens.reducer.ts
+++ b/src/core/store/modules/tokens/tokens.reducer.ts
@@ -37,6 +37,7 @@ const {
   getTokensDynamicData,
   getUserTokens,
   setSelectedTokenAddress,
+  setTokenAllowance,
   approve,
   getTokenAllowance,
   clearTokensData,
@@ -53,6 +54,12 @@ const tokensReducer = createReducer(tokensInitialState, (builder) => {
     /* -------------------------------------------------------------------------- */
     .addCase(setSelectedTokenAddress, (state, { payload: { tokenAddress } }) => {
       state.selectedTokenAddress = tokenAddress;
+    })
+    .addCase(setTokenAllowance, (state, { payload: { tokenAddress, spenderAddress, allowance } }) => {
+      state.user.userTokensAllowancesMap[tokenAddress] = {
+        ...state.user.userTokensAllowancesMap[tokenAddress],
+        [spenderAddress]: allowance,
+      };
     })
 
     /* -------------------------------------------------------------------------- */

--- a/src/core/store/modules/vaults/vaults.actions.ts
+++ b/src/core/store/modules/vaults/vaults.actions.ts
@@ -200,7 +200,7 @@ const approveDeposit = createAsyncThunk<
 
     await transactionService.handleTransaction({ tx, network: network.current });
 
-    const { spender } = await vaultService.getVaultAllowance({
+    const { spender } = await vaultService.getDepositAllowance({
       network: network.current,
       vaultAddress: vaultAddress,
       tokenAddress,
@@ -439,14 +439,14 @@ const approveMigrate = createAsyncThunk<
   unwrapResult(result);
 });
 
-const getVaultAllowance = createAsyncThunk<
+const getDepositAllowance = createAsyncThunk<
   TokenAllowance,
   {
     tokenAddress: string;
     vaultAddress: string;
   },
   ThunkAPI
->('vaults/getVaultAllowance', async ({ vaultAddress, tokenAddress }, { extra, getState, dispatch }) => {
+>('vaults/getDepositAllowance', async ({ vaultAddress, tokenAddress }, { extra, getState, dispatch }) => {
   const {
     services: { vaultService },
   } = extra;
@@ -455,7 +455,7 @@ const getVaultAllowance = createAsyncThunk<
 
   if (!userAddress) throw new Error('WALLET NOT CONNECTED');
 
-  const tokenAllowance = await vaultService.getVaultAllowance({
+  const tokenAllowance = await vaultService.getDepositAllowance({
     network: network.current,
     vaultAddress: vaultAddress,
     tokenAddress,
@@ -585,5 +585,5 @@ export const VaultsActions = {
   getUserVaultsMetadata,
   clearSelectedVaultAndStatus,
   clearVaultStatus,
-  getVaultAllowance,
+  getDepositAllowance,
 };

--- a/src/core/types/Service.ts
+++ b/src/core/types/Service.ts
@@ -54,7 +54,7 @@ export interface VaultService {
   migrate: (props: MigrateProps) => Promise<TransactionResponse>;
   approveDeposit: (props: ApproveDepositProps) => Promise<TransactionResponse>;
   approveZapOut: (props: ApproveZapOutProps) => Promise<TransactionResponse>;
-  getVaultAllowance: (props: GetVaultAllowanceProps) => Promise<TokenAllowance>;
+  getDepositAllowance: (props: GetDepositAllowanceProps) => Promise<TokenAllowance>;
 }
 
 export interface GetSupportedVaultsProps {
@@ -177,7 +177,7 @@ export interface ApproveZapOutProps {
   vaultAddress: string;
 }
 
-export interface GetVaultAllowanceProps {
+export interface GetDepositAllowanceProps {
   network: Network;
   accountAddress: string;
   tokenAddress: string;


### PR DESCRIPTION
## Description

Fixes a race condition on vaults detail view, in which the wallet is not yet connected before it executes, making users unable to deposit.
![image](https://user-images.githubusercontent.com/18649057/166620410-29374ca3-f0a0-4c98-868a-76540f4eb006.png)

## Motivation and Context

Refactored the deposit modals to fetch token allowance directly instead of using useAllowance hook, since was unable to make it work through the hook.

## How Has This Been Tested?

Reloaded vault detail page multiple times with wallet connected.
Approved tokens in fantom network to test functionality. Also tested labs.
@FoxTheSin help needed with QA.
