### PR TITLE
fix: pull yvBOOST balance from lab positions and fix icon URL

### DIFF
--- a/src/config/constants/index.ts
+++ b/src/config/constants/index.ts
@@ -118,5 +118,6 @@ export const getConstants = memoize((): Constants => {
     SUPPORTED_LANGS: ['en', 'es'],
     DUST_AMOUNT_USD: '10000000',
     YEARN_SUBGRAPH_ID: '5xMSe3wTNLgFQqsAc5SCVVwT4MiRb5AogJCuSN9PjzXF',
+    ASSETS_ICON_URL: 'https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/multichain-tokens/1/',
   };
 });

--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -65,6 +65,7 @@ export class LabServiceImpl implements LabService {
     const errors: string[] = [];
     const { YEARN_API, CONTRACT_ADDRESSES } = this.config;
     const { ETH, YVECRV, CRV, YVBOOST, PSLPYVBOOSTETH } = CONTRACT_ADDRESSES;
+    const { ASSETS_ICON_URL } = getConstants();
     const yearn = this.yearnSdk.getInstanceOf(network);
     const providerType = getProviderType(network);
     const provider = this.web3Provider.getInstanceOf(providerType);
@@ -128,7 +129,7 @@ export class LabServiceImpl implements LabService {
               }
             : undefined,
           displayName: backscratcherData.name,
-          displayIcon: `${getConstants().ASSETS_ICON_URL}${YVECRV}/logo-128.png`,
+          displayIcon: `${ASSETS_ICON_URL}${YVECRV}/logo-128.png`,
           defaultDisplayToken: CRV,
         },
       };
@@ -169,7 +170,7 @@ export class LabServiceImpl implements LabService {
         underlyingTokenBalance,
         metadata: {
           ...yvBoostVaultDynamic.metadata,
-          displayIcon: `${getConstants().ASSETS_ICON_URL}${address}/logo-128.png`,
+          displayIcon: `${ASSETS_ICON_URL}${address}/logo-128.png`,
         },
       };
     } catch (error) {
@@ -227,7 +228,7 @@ export class LabServiceImpl implements LabService {
           pricePerShare: pJarRatio.toString(),
           apy: { ...pJarData.apy, net_apy: toBN(performance.toString()).dividedBy(100).toNumber() },
           displayName: 'pSLPyvBOOST-ETH',
-          displayIcon: `${getConstants().ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
+          displayIcon: `${ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
           defaultDisplayToken: ETH,
         },
       };

--- a/src/core/services/LabService.ts
+++ b/src/core/services/LabService.ts
@@ -19,6 +19,7 @@ import {
   GetSupportedLabsProps,
 } from '@types';
 import { get, toBN, normalizeAmount, USDC_DECIMALS, getStakingContractAddress, getProviderType } from '@utils';
+import { getConstants } from '@config/constants';
 
 import backscratcherAbi from './contracts/backscratcher.json';
 import y3CrvBackZapperAbi from './contracts/y3CrvBackZapper.json';
@@ -72,8 +73,6 @@ export class LabServiceImpl implements LabService {
       'https://api.coingecko.com/api/v3/simple/price?ids=curve-dao-token,vecrv-dao-yvault&vs_currencies=usd'
     );
     const [vaultsResponse, pricesResponse] = await Promise.all([vaultsPromise, pricesPromise]);
-
-    const ASSET_URL = 'https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/multichain-tokens/1/';
 
     // **************** BACKSCRATCHER ****************
     let backscratcherLab: Lab | undefined;
@@ -129,7 +128,7 @@ export class LabServiceImpl implements LabService {
               }
             : undefined,
           displayName: backscratcherData.name,
-          displayIcon: `${ASSET_URL}${YVECRV}/logo-128.png`,
+          displayIcon: `${getConstants().ASSETS_ICON_URL}${YVECRV}/logo-128.png`,
           defaultDisplayToken: CRV,
         },
       };
@@ -170,7 +169,7 @@ export class LabServiceImpl implements LabService {
         underlyingTokenBalance,
         metadata: {
           ...yvBoostVaultDynamic.metadata,
-          displayIcon: `${ASSET_URL}${address}/logo-128.png`,
+          displayIcon: `${getConstants().ASSETS_ICON_URL}${address}/logo-128.png`,
         },
       };
     } catch (error) {
@@ -228,7 +227,7 @@ export class LabServiceImpl implements LabService {
           pricePerShare: pJarRatio.toString(),
           apy: { ...pJarData.apy, net_apy: toBN(performance.toString()).dividedBy(100).toNumber() },
           displayName: 'pSLPyvBOOST-ETH',
-          displayIcon: `${ASSET_URL}${PSLPYVBOOSTETH}/logo-128.png`,
+          displayIcon: `${getConstants().ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
           defaultDisplayToken: ETH,
         },
       };

--- a/src/core/services/TokenService.ts
+++ b/src/core/services/TokenService.ts
@@ -108,6 +108,7 @@ export class TokenServiceImpl implements TokenService {
 
   private async getYvBoostToken(): Promise<Token> {
     const { YVBOOST } = this.config.CONTRACT_ADDRESSES;
+    const { ASSETS_ICON_URL } = getConstants();
     const pricesResponse = await get('https://api.coingecko.com/api/v3/simple/price?ids=yvboost&vs_currencies=usd');
     const yvBoostPrice = pricesResponse.data['yvboost']['usd'];
     return {
@@ -122,13 +123,14 @@ export class TokenServiceImpl implements TokenService {
         zapper: false,
       },
       symbol: 'yvBOOST',
-      icon: `${getConstants().ASSETS_ICON_URL}${YVBOOST}/logo-128.png`,
+      icon: `${ASSETS_ICON_URL}${YVBOOST}/logo-128.png`,
     };
   }
 
   private async getPSLPyvBoostEthToken(): Promise<Token> {
     const { ZAPPER_API_KEY } = this.config;
     const { PSLPYVBOOSTETH } = this.config.CONTRACT_ADDRESSES;
+    const { ASSETS_ICON_URL } = getConstants();
     const pricesResponse = await get(
       `https://api.zapper.fi/v1/protocols/pickle/token-market-data?api_key=${ZAPPER_API_KEY}&type=vault`
     );
@@ -147,7 +149,7 @@ export class TokenServiceImpl implements TokenService {
         zapper: false,
       },
       symbol: 'pSLPyvBOOST-ETH',
-      icon: `${getConstants().ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
+      icon: `${ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
     };
   }
 

--- a/src/core/services/TokenService.ts
+++ b/src/core/services/TokenService.ts
@@ -18,6 +18,7 @@ import {
 } from '@types';
 import { getContract } from '@frameworks/ethers';
 import { get, getUniqueAndCombine, toBN, USDC_DECIMALS } from '@utils';
+import { getConstants } from '@config/constants';
 
 import erc20Abi from './contracts/erc20.json';
 
@@ -121,7 +122,7 @@ export class TokenServiceImpl implements TokenService {
         zapper: false,
       },
       symbol: 'yvBOOST',
-      icon: `https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/tokens/${YVBOOST}/logo-128.png`,
+      icon: `${getConstants().ASSETS_ICON_URL}${YVBOOST}/logo-128.png`,
     };
   }
 
@@ -146,7 +147,7 @@ export class TokenServiceImpl implements TokenService {
         zapper: false,
       },
       symbol: 'pSLPyvBOOST-ETH',
-      icon: `https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/tokens/${PSLPYVBOOSTETH}/logo-128.png`,
+      icon: `${getConstants().ASSETS_ICON_URL}${PSLPYVBOOSTETH}/logo-128.png`,
     };
   }
 

--- a/src/core/store/modules/labs/labs.selectors.ts
+++ b/src/core/store/modules/labs/labs.selectors.ts
@@ -31,7 +31,33 @@ const selectUserYveCrvTokenData = (state: RootState) => state.tokens.user.userTo
 const selectYveCrvTokenAllowancesMap = (state: RootState) => state.tokens.user.userTokensAllowancesMap[YVECRV];
 
 const selectYvBoostData = (state: RootState) => state.tokens.tokensMap[YVBOOST];
-const selectUserYvBoostData = (state: RootState) => state.tokens.user.userTokensMap[YVBOOST];
+const selectUserYvBoostData = (state: RootState) => {
+  const userToken = state.tokens.user.userTokensMap[YVBOOST];
+  if (userToken) {
+    return userToken;
+  }
+
+  // if yvBOOST not in userTokensMap, get balance from lab positions
+  const token = state.tokens.tokensMap[YVBOOST];
+  const position = state.labs.user.userLabsPositionsMap[YVBOOST]?.DEPOSIT;
+  if (!token || !position) {
+    return userToken;
+  }
+
+  const balance: Balance = {
+    address: position.assetAddress,
+    token: {
+      address: token.address,
+      name: token.name,
+      symbol: token.symbol,
+      decimals: token.decimals,
+    },
+    balance: position.balance,
+    balanceUsdc: position.underlyingTokenBalance.amountUsdc,
+    priceUsdc: token.priceUsdc,
+  };
+  return balance;
+};
 const selectYvBoostAllowancesMap = (state: RootState) => state.tokens.user.userTokensAllowancesMap[YVBOOST];
 
 const selectSelectedLabAddress = (state: RootState) => state.labs.selectedLabAddress;

--- a/src/core/types/Config.ts
+++ b/src/core/types/Config.ts
@@ -47,4 +47,5 @@ export interface Constants {
   SUPPORTED_LANGS: Language[];
   DUST_AMOUNT_USD: string;
   YEARN_SUBGRAPH_ID: string;
+  ASSETS_ICON_URL: string;
 }


### PR DESCRIPTION
## Description

* It seems like yvBOOST token balances don't show up for pickle jar because the yvBOOST token is not fetched with all other user tokens. To fix this, I override the user tokens balance with the lab positions data. This is kind of hacky but it seems cleaner than trying to force fetch yvBOOST tokens with all the other user tokens

* There was also an issue with a broken asset icon URL in TokenService (but the correct URL was in LabService), so I fixed that by creating a constant to share between them

## Related Issue

Fixes #627

## Motivation and Context

yvBOOST token balances now show up for pickle jar

## How Has This Been Tested?

Manually checked labs with the following address (which has assets in pickle jar): 0x24a21d91c82d684cd793e3829318a33784ef3626

## Screenshots (if appropriate):

![Screen Shot 2022-05-06 at 1 01 44 PM](https://user-images.githubusercontent.com/21136804/167201471-1f567f48-b3e6-4b26-87f0-a31c25ebeedb.png)

![Screen Shot 2022-05-06 at 1 01 58 PM](https://user-images.githubusercontent.com/21136804/167201493-60435d73-a267-4d5a-abb3-efa0b30b9031.png)

