### PR TITLE
fix: Improve visibility of icon button color

### DIFF
--- a/src/client/components/app/ActionButtons/index.tsx
+++ b/src/client/components/app/ActionButtons/index.tsx
@@ -20,7 +20,7 @@ const AlertButton = styled.div`
   justify-content: center;
   border-radius: 0.8rem;
   border: 2px solid ${({ theme }) => theme.colors.vaultActionButton.selected.borderColor};
-  background: ${({ theme }) => theme.colors.vaultActionButton.borderColor};
+  background: ${({ theme }) => theme.colors.vaultActionButton.iconFill};
   width: 2.8rem;
   height: 2.8rem;
 `;

--- a/src/client/themes/classic/index.ts
+++ b/src/client/themes/classic/index.ts
@@ -96,6 +96,7 @@ const classicTheme: DefaultTheme = {
       background: 'transparent',
       borderColor: '#fff',
       color: '#fff',
+      iconFill: classic.colors.backgroundVariant,
       // disabledContrast: '0.1',
 
       selected: {

--- a/src/client/themes/cyberpunk/index.ts
+++ b/src/client/themes/cyberpunk/index.ts
@@ -53,6 +53,7 @@ const cyberpunkTheme: DefaultTheme = {
       background: 'transparent',
       borderColor: '#BB6FA1',
       color: '#BB6FA1',
+      iconFill: '#3D305F',
       // disabledContrast: '0.6',
 
       selected: {

--- a/src/client/themes/dark/index.ts
+++ b/src/client/themes/dark/index.ts
@@ -91,6 +91,7 @@ const darkTheme: DefaultTheme = {
       background: '#272727',
       borderColor: 'transparent',
       color: '#FFFFFF',
+      iconFill: dark.colors.backgroundVariant,
       // disabledContrast: '1.5',
 
       selected: {

--- a/src/client/themes/explorer/index.ts
+++ b/src/client/themes/explorer/index.ts
@@ -61,6 +61,7 @@ const explorerTheme: DefaultTheme = {
       background: 'transparent',
       borderColor: '#eeeeee',
       color: '#eeeeee',
+      iconFill: '#cfa368',
       // disabledContrast: '',
 
       selected: {

--- a/src/client/themes/light/index.ts
+++ b/src/client/themes/light/index.ts
@@ -95,6 +95,7 @@ const lightTheme: DefaultTheme = {
       background: light.colors.secondary,
       borderColor: light.colors.secondary,
       color: light.colors.titlesVariant,
+      iconFill: light.colors.backgroundVariant,
       // disabledContrast: '1',
 
       selected: {

--- a/src/client/themes/styled.d.ts
+++ b/src/client/themes/styled.d.ts
@@ -131,6 +131,7 @@ declare module 'styled-components' {
         background: string;
         borderColor: string;
         color: string;
+        iconFill: string;
         // disabledContrast: string;
 
         selected: {


### PR DESCRIPTION
## Description

- Icon button is not clearly visible for certain themes, e.g. classic.
- Added `colors.vaultActionButton.fillColor` prop to use `colors.backgroundVariant` which makes icon button visible for all themes.

## Related Issue
#629

## Motivation and Context

- Improve visibility of icon button and user experience.

## How Has This Been Tested?

- Running locally and checking icon color in all the themes.

## Screenshots (if appropriate):
- Refer to #629.
