### PR TITLE
fix: Improve footer text visibility

### DIFF
--- a/src/client/components/app/Footer/index.tsx
+++ b/src/client/components/app/Footer/index.tsx
@@ -72,7 +72,7 @@ const LinkSection = styled.div`
   column-gap: ${({ theme }) => theme.card.padding};
   row-gap: 1rem;
   flex: 1;
-  color: ${({ theme }) => theme.colors.icons.variant};
+  color: ${({ theme }) => theme.colors.icons.text};
 `;
 
 const StyledLink = styled(Link)`

--- a/src/client/themes/classic/index.ts
+++ b/src/client/themes/classic/index.ts
@@ -22,6 +22,7 @@ const classic = {
     icons: {
       primary: '#7F8DA9',
       variant: '#FFFFFF',
+      text: '#012A7C',
     },
     button: {
       filled: {
@@ -62,6 +63,7 @@ const classicTheme: DefaultTheme = {
     icons: {
       primary: classic.colors.icons.primary,
       variant: classic.colors.icons.variant,
+      text: classic.colors.icons.text,
     },
     titles: classic.colors.titles,
     titlesVariant: classic.colors.titlesVariant,

--- a/src/client/themes/cyberpunk/index.ts
+++ b/src/client/themes/cyberpunk/index.ts
@@ -19,6 +19,7 @@ const cyberpunkTheme: DefaultTheme = {
     icons: {
       primary: '#0CA7C9',
       variant: '#0CA7C9',
+      text: '#0CA7C9',
     },
     titles: '#0CA7C9',
     titlesVariant: '#0CA7C9',

--- a/src/client/themes/dark/index.ts
+++ b/src/client/themes/dark/index.ts
@@ -20,6 +20,7 @@ const dark = {
     icons: {
       primary: '#A8A8A8',
       variant: '#FFFFFF',
+      text: '#FFFFFF',
     },
     button: {
       filled: {
@@ -57,6 +58,7 @@ const darkTheme: DefaultTheme = {
     icons: {
       primary: dark.colors.icons.primary,
       variant: dark.colors.icons.variant,
+      text: dark.colors.icons.text,
     },
     titles: dark.colors.titles,
     titlesVariant: dark.colors.titlesVariant,

--- a/src/client/themes/explorer/index.ts
+++ b/src/client/themes/explorer/index.ts
@@ -27,6 +27,7 @@ const explorerTheme: DefaultTheme = {
     icons: {
       primary: '#AD3235',
       variant: '#FFF',
+      text: '#FFF',
     },
     titles: '#FFF',
     titlesVariant: '#AD3235',

--- a/src/client/themes/light/index.ts
+++ b/src/client/themes/light/index.ts
@@ -20,6 +20,7 @@ const light = {
     icons: {
       primary: '#CED5E3',
       variant: '#475570',
+      text: '#475570',
     },
     button: {
       filled: {
@@ -61,6 +62,7 @@ const lightTheme: DefaultTheme = {
     icons: {
       primary: light.colors.icons.primary,
       variant: light.colors.icons.variant,
+      text: light.colors.icons.text,
     },
     titles: light.colors.titles,
     titlesVariant: light.colors.titlesVariant,

--- a/src/client/themes/styled.d.ts
+++ b/src/client/themes/styled.d.ts
@@ -96,6 +96,7 @@ declare module 'styled-components' {
       icons: {
         primary: string;
         variant: string;
+        text: string;
       };
       titles: string;
       titlesVariant: string;


### PR DESCRIPTION
## Description

- Footer text is not clearly visible for the classic theme.
- Added `colors.icons.text` prop to use `#012A7C` for the classic theme and `colors.icons.variant` for other themes.

## Related Issue

- Fixes #633

## Motivation and Context

- Improve visibility of footer text and user experience.

## How Has This Been Tested?

- Running locally and checking footer text in classic theme.

## Screenshots (if appropriate):
![footer](https://user-images.githubusercontent.com/83656073/167249393-bafe2dbe-0395-4072-b720-f9a056c9d489.jpg)

