### PR TITLE
fix: settings padding for section title

### DIFF
--- a/src/client/routes/Settings/index.tsx
+++ b/src/client/routes/Settings/index.tsx
@@ -33,7 +33,7 @@ const SettingsCard = styled(Card)`
 
 const SettingsSection = styled.div`
   display: grid;
-  grid-template-columns: 15rem 1fr;
+  grid-template-columns: 18rem 1fr;
   padding: 0 ${({ theme }) => theme.card.padding};
   grid-gap: ${({ theme }) => theme.layoutPadding};
 `;
@@ -53,6 +53,10 @@ const SectionTitle = styled.div<{ centerText?: boolean }>`
   display: flex;
   align-items: ${({ centerText }) => (centerText ? 'center' : 'flex-start')};
   fill: currentColor;
+
+  ${SettingsSection}:not(:first-child) & {
+    padding-top: ${({ theme }) => theme.card.padding};
+  }
 `;
 
 const SectionHeading = styled.h3`


### PR DESCRIPTION
## Description

* It looks like the section title is missing padding that is currently applied to section content, so all of the titles are misaligned
* I also increased column width of the title so that "Enable Signed Approvals" can fit on a single line

## Related Issue

Fixes #640 

## Motivation and Context

Improves section title spacing 

## How Has This Been Tested?

Manually tested

## Screenshots (if appropriate):

Before:

![Screen Shot 2022-05-09 at 4 42 44 PM](https://user-images.githubusercontent.com/21136804/167510415-9c7f9273-aa28-4216-8016-eab6d8531c16.png)

After: 
![Screen Shot 2022-05-09 at 4 42 28 PM](https://user-images.githubusercontent.com/21136804/167510384-cd3fe337-30ab-4557-896f-a847994a26f5.png)

