### PR TITLE
feat: add breadcrumb to vaults for vault details

### DIFF
--- a/src/client/components/app/Navbar/index.tsx
+++ b/src/client/components/app/Navbar/index.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { ConnectWalletButton } from '@components/app';
-import { OptionList, EthereumIcon, FantomIcon, ArbitrumIcon } from '@components/common';
+import { OptionList, EthereumIcon, FantomIcon, ArbitrumIcon, Link } from '@components/common';
 import { useWindowDimensions } from '@hooks';
 import { Network } from '@types';
 import { device } from '@themes/default';
@@ -38,6 +38,11 @@ const StyledText = styled.h1<{ toneDown?: boolean }>`
     `
     color: ${theme.colors.texts};
   `}
+`;
+
+const StyledLink = styled(Link)`
+  font-size: 2.4rem;
+  font-weight: 700;
 `;
 
 const StyledNavbar = styled.header`
@@ -79,6 +84,7 @@ const getNetworkIcon = (network: Network) => {
 interface NavbarProps {
   className?: string;
   title?: string;
+  titleLink?: string;
   subTitle?: string;
   walletAddress?: string;
   addressEnsName?: string;
@@ -94,6 +100,7 @@ interface NavbarProps {
 export const Navbar = ({
   className,
   title,
+  titleLink,
   subTitle,
   walletAddress,
   addressEnsName,
@@ -131,7 +138,7 @@ export const Navbar = ({
     <StyledNavbar className={className}>
       {title && (
         <StyledText toneDown={secondTitleEnabled}>
-          {title}
+          {titleLink ? <StyledLink to={titleLink}>{title}</StyledLink> : title}
           {secondTitleEnabled && vaultText}
         </StyledText>
       )}

--- a/src/client/containers/Layout/index.tsx
+++ b/src/client/containers/Layout/index.tsx
@@ -107,9 +107,11 @@ export const Layout: FC = ({ children }) => {
   const hideControls = partner.id === 'ledger';
 
   let vaultName;
+  let titleLink;
   // TODO Add lab details route when its added the view
   if (path === 'vault') {
     vaultName = selectedVault?.displayName;
+    titleLink = '/vaults';
   }
 
   // TODO This is only assetAddress on the vault page
@@ -188,6 +190,7 @@ export const Layout: FC = ({ children }) => {
       <Content collapsedSidebar={collapsedSidebar} useTabbar={isMobile}>
         <Navbar
           title={t(`navigation.${path}`)}
+          titleLink={titleLink}
           subTitle={vaultName}
           walletAddress={selectedAddress}
           addressEnsName={addressEnsName}


### PR DESCRIPTION
## Description

* Adds breadcrumbs that link back to vault page

## Related Issue

Fixes #646

## Motivation and Context

## How Has This Been Tested?

* Manually tested clicking the link, keyboard navigation

## Screenshots (if appropriate):

![Screen Shot 2022-05-10 at 8 28 28 AM](https://user-images.githubusercontent.com/21136804/167652788-fc3ba332-2e33-48cf-8d15-d852a7b80646.png)

