### PR TITLE
fix: gnosis safe wallet name

### DIFF
--- a/src/core/store/modules/app/app.actions.ts
+++ b/src/core/store/modules/app/app.actions.ts
@@ -47,7 +47,7 @@ const initApp = createAsyncThunk<void, void, ThunkAPI>('app/initApp', async (_ar
     await dispatch(PartnerActions.changePartner({ id: 'ledger', address: CONTRACT_ADDRESSES.LEDGER }));
   } else if (isGnosisApp()) {
     if (network.current !== 'mainnet') await dispatch(NetworkActions.changeNetwork({ network: 'mainnet' }));
-    await dispatch(WalletActions.walletSelect({ walletName: 'gnosis', network: 'mainnet' }));
+    await dispatch(WalletActions.walletSelect({ walletName: 'Gnosis Safe', network: 'mainnet' }));
   } else if (wallet.name && wallet.name !== 'Iframe') {
     await dispatch(WalletActions.walletSelect({ walletName: wallet.name, network: network.current }));
   }

--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -7,9 +7,6 @@ export const isInIframe = () => {
 };
 
 export const isLoadedInOtherDomain = (domain: string) => {
-  // TODO: remove logs when verified iframes work as expected
-  console.log('ancestorOrigins', window?.location?.ancestorOrigins);
-  console.log('referrer', document?.referrer);
   return (
     isInIframe() && (window?.location?.ancestorOrigins?.[0]?.includes(domain) || document?.referrer?.includes(domain))
   );


### PR DESCRIPTION
## Description

Fix issue of gnosis wallet not connecting on gnosis safe app init

## Motivation and Context

Blocknative's Onboard uses a different naming when it is saved on local storage than on library initialization [here](https://github.com/yearn/yearn-finance-v3/blob/develop/src/core/frameworks/blocknative/Onboard.ts#L94)

![image](https://user-images.githubusercontent.com/18649057/167719552-764c062d-a6ab-4bf6-97db-fc37fbd05d99.png)

## How Has This Been Tested?

Needs to be tested until merged, since cant load gnosis app from preview build.
