### PR TITLE
fix: Vault search and filter

### DIFF
--- a/src/client/routes/Vaults/index.tsx
+++ b/src/client/routes/Vaults/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
-import { useAppSelector, useAppDispatch, useIsMounting, useAppTranslation } from '@hooks';
+import { useAppSelector, useAppDispatch, useIsMounting, useAppTranslation, usePrevious } from '@hooks';
 import {
   ModalsActions,
   ModalSelectors,
@@ -167,6 +167,7 @@ export const Vaults = () => {
   const deprecated = useAppSelector(VaultsSelectors.selectDeprecatedVaults);
   const deposits = useAppSelector(VaultsSelectors.selectDepositedVaults);
   const opportunities = useAppSelector(VaultsSelectors.selectVaultsOpportunities);
+  const previousOpportunities = usePrevious(opportunities);
   const [filteredVaults, setFilteredVaults] = useState(opportunities);
   const activeModal = useAppSelector(ModalSelectors.selectActiveModal);
 
@@ -179,8 +180,10 @@ export const Vaults = () => {
   const depositsLoading = generalLoading && !deposits.length;
 
   useEffect(() => {
-    setFilteredVaults(opportunities);
-  }, [opportunities]);
+    if (previousOpportunities?.length !== opportunities.length) {
+      setFilteredVaults(opportunities);
+    }
+  }, [opportunities, previousOpportunities]);
 
   const depositHandler = (vaultAddress: string) => {
     dispatch(VaultsActions.setSelectedVaultAddress({ vaultAddress }));


### PR DESCRIPTION
## Description

- Vault search and filter function is not working properly after clicking on the deposit button.
- Steps to reproduce:
  - Go to the vaults page at `/vaults`.
  - Type something in the search box located in the Opportunities box.
  - See vaults get filtered.
  - Click on 'Deposit' on any of the vaults.
  - Dismiss modal.
  - Filter is removed but search box still contains text.
- Fix by running the `useEffect` only when `opportunities` length is changed.
- `setFilteredVaults` will be managed by `SearchInput` and will not be overridden by the `useEffect` call.

## Motivation and Context

- Maintain consistency between search text and filter.

## How Has This Been Tested?

- Tried searching 'usdt', clicking on 'Deposit', then dismissing the modal, and observing the filter behavior.

## Screenshots (if appropriate):
1) During search
![during-search](https://user-images.githubusercontent.com/83656073/167749657-7a4c9905-2e85-4439-9070-6773ac8d6822.jpg)

2) After clicking on 'Deposit' and dismissing modal
![after-deposit](https://user-images.githubusercontent.com/83656073/167749924-6e8c8827-070b-4515-afd5-7782d5e7f3ca.jpg)

Fix will maintain the filter shown in 1) after clicking on deposit and dismissing modal.