### PR TITLE
feat: Display only Zapable Tokens by vault WEB-1013

### DIFF
--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -183,6 +183,7 @@ export const DepositTx: FC<DepositTxProps> = ({
 
   const vaultsOptions = vaults
     .filter(({ address }) => allowVaultSelect || selectedVault.address === address)
+    .filter(({ token }) => token.zaps.zapperZapIn)
     .map(({ address, displayName, displayIcon, DEPOSIT, token, apyData, apyMetadata }) => ({
       address,
       symbol: displayName,
@@ -191,6 +192,10 @@ export const DepositTx: FC<DepositTxProps> = ({
       balanceUsdc: DEPOSIT.userDepositedUsdc,
       decimals: token.decimals,
       yield: formatApy(apyData, apyMetadata?.type),
+      zapper: token.zaps.zapper,
+      zapperZapIn: token.zaps.zapperZapIn,
+      zapperZapOut: token.zaps.zapperZapOut,
+      ftmApeZap: token.zaps.ftmApeZap,
     }));
   const selectedVaultOption = vaultsOptions.find(({ address }) => address === selectedVault.address)!;
 

--- a/src/client/components/app/Transactions/Transaction.tsx
+++ b/src/client/components/app/Transactions/Transaction.tsx
@@ -31,6 +31,10 @@ interface Asset {
   balanceUsdc: string;
   decimals: number;
   yield?: string;
+  zapper?: boolean;
+  zapperZapIn?: boolean;
+  zapperZapOut?: boolean;
+  ftmApeZap?: boolean;
 }
 
 interface TransactionProps {

--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -139,7 +139,17 @@ export const Labs = () => {
     setFilteredOpportunities(opportunities);
   }, [opportunities]);
 
-  const LabHoldingsActions = ({ labAddress, alert }: { labAddress: string; alert?: string }) => {
+  const LabHoldingsActions = ({
+    labAddress,
+    alert,
+    allowZapIn,
+    allowZapOut,
+  }: {
+    labAddress: string;
+    alert?: string;
+    allowZapIn: boolean;
+    allowZapOut: boolean;
+  }) => {
     switch (labAddress) {
       case YVECRV:
         return (
@@ -176,22 +186,30 @@ export const Labs = () => {
         return (
           <ActionButtons
             actions={[
-              {
-                name: t('components.transaction.deposit'),
-                handler: () => {
-                  dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
-                  dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
-                },
-                disabled: !walletIsConnected,
-              },
-              {
-                name: t('components.transaction.withdraw'),
-                handler: () => {
-                  dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
-                  dispatch(ModalsActions.openModal({ modalName: 'labWithdrawTx' }));
-                },
-                disabled: !walletIsConnected,
-              },
+              ...(allowZapIn
+                ? [
+                    {
+                      name: t('components.transaction.deposit'),
+                      handler: () => {
+                        dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
+                        dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
+                      },
+                      disabled: !walletIsConnected,
+                    },
+                  ]
+                : []),
+              ...(allowZapOut
+                ? [
+                    {
+                      name: t('components.transaction.withdraw'),
+                      handler: () => {
+                        dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
+                        dispatch(ModalsActions.openModal({ modalName: 'labWithdrawTx' }));
+                      },
+                      disabled: !walletIsConnected,
+                    },
+                  ]
+                : []),
             ]}
           />
         );
@@ -200,14 +218,18 @@ export const Labs = () => {
           <ActionButtons
             alert={alert}
             actions={[
-              {
-                name: t('components.transaction.deposit'),
-                handler: () => {
-                  dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
-                  dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
-                },
-                disabled: !walletIsConnected,
-              },
+              ...(allowZapIn
+                ? [
+                    {
+                      name: t('components.transaction.deposit'),
+                      handler: () => {
+                        dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
+                        dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
+                      },
+                      disabled: !walletIsConnected,
+                    },
+                  ]
+                : []),
               {
                 name: t('components.transaction.stake'),
                 handler: () => {
@@ -224,7 +246,7 @@ export const Labs = () => {
     }
   };
 
-  const LabOpportunitiesActions = ({ labAddress }: { labAddress: string }) => {
+  const LabOpportunitiesActions = ({ labAddress, allowZapIn }: { labAddress: string; allowZapIn: boolean }) => {
     switch (labAddress) {
       case YVECRV:
         return (
@@ -246,14 +268,18 @@ export const Labs = () => {
         return (
           <ActionButtons
             actions={[
-              {
-                name: t('components.transaction.deposit'),
-                handler: () => {
-                  dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
-                  dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
-                },
-                disabled: !walletIsConnected,
-              },
+              ...(allowZapIn
+                ? [
+                    {
+                      name: t('components.transaction.deposit'),
+                      handler: () => {
+                        dispatch(LabsActions.setSelectedLabAddress({ labAddress }));
+                        dispatch(ModalsActions.openModal({ modalName: 'labDepositTx' }));
+                      },
+                      disabled: !walletIsConnected,
+                    },
+                  ]
+                : []),
             ]}
           />
         );
@@ -376,7 +402,14 @@ export const Labs = () => {
                 },
                 {
                   key: 'actions',
-                  transform: ({ address, alert }) => <LabHoldingsActions labAddress={address} alert={alert} />,
+                  transform: ({ address, alert, allowZapIn, allowZapOut }) => (
+                    <LabHoldingsActions
+                      labAddress={address}
+                      alert={alert}
+                      allowZapIn={allowZapIn}
+                      allowZapOut={allowZapOut}
+                    />
+                  ),
                   align: 'flex-end',
                   width: 'auto',
                   grow: '1',
@@ -443,7 +476,9 @@ export const Labs = () => {
                 },
                 {
                   key: 'actions',
-                  transform: ({ address }) => <LabOpportunitiesActions labAddress={address} />,
+                  transform: ({ address, allowZapIn, allowZapOut }) => (
+                    <LabOpportunitiesActions labAddress={address} allowZapIn={allowZapIn} />
+                  ),
                   align: 'flex-end',
                   width: 'auto',
                   grow: '1',

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -258,8 +258,8 @@ export const Portfolio = () => {
             },
             {
               key: 'invest',
-              transform: ({ address, isZapperZapIn, isFtmApeZap }) => (
-                <ActionButtons actions={[...investButton({ address, isZapIn: isZapperZapIn || isFtmApeZap })]} />
+              transform: ({ address, zaps }) => (
+                <ActionButtons actions={[...investButton({ address, isZapIn: zaps.zapperZapIn ?? false })]} />
               ),
               align: 'flex-end',
               width: 'auto',

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -153,12 +153,12 @@ export const Portfolio = () => {
     }
   };
 
-  const investButton = (tokenAddress: string, isZapable: boolean) => {
+  const investButton = ({ address, isZapIn }: { address: string; isZapIn: boolean }) => {
     return [
       {
         name: t('components.transaction.deposit'),
-        handler: () => actionHandler('invest', tokenAddress),
-        disabled: !walletIsConnected || !(isZapable || vaultsUnderlyingTokens.includes(tokenAddress)),
+        handler: () => actionHandler('invest', address),
+        disabled: !walletIsConnected || !(isZapIn || vaultsUnderlyingTokens.includes(address)),
       },
     ];
   };
@@ -258,7 +258,9 @@ export const Portfolio = () => {
             },
             {
               key: 'invest',
-              transform: ({ address, isZapable }) => <ActionButtons actions={[...investButton(address, isZapable)]} />,
+              transform: ({ address, isZapperZapIn, isFtmApeZap }) => (
+                <ActionButtons actions={[...investButton({ address, isZapIn: isZapperZapIn || isFtmApeZap })]} />
+              ),
               align: 'flex-end',
               width: 'auto',
               grow: '1',

--- a/src/client/routes/Vaults/index.tsx
+++ b/src/client/routes/Vaults/index.tsx
@@ -372,14 +372,30 @@ export const Vaults = () => {
                 },
                 {
                   key: 'actions',
-                  transform: ({ address }) => (
-                    <ActionButtons
-                      actions={[
-                        { name: t('components.transaction.deposit'), handler: () => depositHandler(address) },
-                        { name: t('components.transaction.withdraw'), handler: () => withdrawHandler(address) },
-                      ]}
-                    />
-                  ),
+                  transform: ({ address, allowZapIn, allowZapOut }) => {
+                    return (
+                      <ActionButtons
+                        actions={[
+                          ...(allowZapIn
+                            ? [
+                                {
+                                  name: t('components.transaction.deposit'),
+                                  handler: () => depositHandler(address),
+                                },
+                              ]
+                            : []),
+                          ...(allowZapOut
+                            ? [
+                                {
+                                  name: t('components.transaction.withdraw'),
+                                  handler: () => withdrawHandler(address),
+                                },
+                              ]
+                            : []),
+                        ]}
+                      />
+                    );
+                  },
                   align: 'flex-end',
                   width: 'auto',
                   grow: '1',
@@ -445,14 +461,18 @@ export const Vaults = () => {
                 },
                 {
                   key: 'actions',
-                  transform: ({ address }) => (
+                  transform: ({ address, allowZapIn }) => (
                     <ActionButtons
                       actions={[
-                        {
-                          name: t('components.transaction.deposit'),
-                          handler: () => depositHandler(address),
-                          disabled: !walletIsConnected,
-                        },
+                        ...(allowZapIn
+                          ? [
+                              {
+                                name: t('components.transaction.deposit'),
+                                handler: () => depositHandler(address),
+                                disabled: !walletIsConnected,
+                              },
+                            ]
+                          : []),
                       ]}
                     />
                   ),

--- a/src/core/store/modules/tokens/tokens.selectors.ts
+++ b/src/core/store/modules/tokens/tokens.selectors.ts
@@ -41,7 +41,7 @@ const selectSummaryData = createSelector([selectUserTokens], (userTokens) => {
 });
 
 const selectZapInTokens = createSelector([selectUserTokens], (userTokens) => {
-  return userTokens.filter(({ isZapperZapIn }) => isZapperZapIn);
+  return userTokens.filter(({ zaps: { zapperZapIn } }) => zapperZapIn);
 });
 
 const selectZapOutTokens = createSelector([selectTokensMap, selectUserTokensMap], (tokensMap, userTokensMap) => {
@@ -86,18 +86,19 @@ const selectWalletTokensStatus = createSelector(
 
 /* --------------------------------- Helper --------------------------------- */
 interface CreateTokenProps {
-  tokenData: Token;
+  tokenData?: Token;
   userTokenData: Balance;
   allowancesMap: AllowancesMap;
 }
 
 export function createToken(props: CreateTokenProps): TokenView {
   const { tokenData, userTokenData, allowancesMap } = props;
+
   return {
-    address: tokenData?.address,
-    name: tokenData?.name,
-    symbol: tokenData?.symbol,
-    decimals: parseInt(tokenData?.decimals),
+    address: tokenData?.address ?? '',
+    name: tokenData?.name ?? '',
+    symbol: tokenData?.symbol ?? '',
+    decimals: parseInt(tokenData?.decimals ?? '0'),
     icon: tokenData?.icon,
     balance: userTokenData?.balance ?? '0',
     balanceUsdc: userTokenData?.balanceUsdc ?? '0',
@@ -105,9 +106,12 @@ export function createToken(props: CreateTokenProps): TokenView {
     categories: tokenData?.metadata?.categories ?? [],
     description: tokenData?.metadata?.description ?? '',
     website: tokenData?.metadata?.website ?? '',
-    isZapperZapIn: tokenData?.supported.zapperZapIn ?? false,
-    isZapperZapOut: tokenData?.supported.zapperZapOut ?? false,
-    isFtmApeZap: tokenData?.supported.ftmApeZap ?? false,
+    zaps: {
+      zapper: tokenData?.supported.zapper,
+      zapperZapIn: tokenData?.supported.zapperZapIn,
+      zapperZapOut: tokenData?.supported.zapperZapOut,
+      ftmApeZap: tokenData?.supported.ftmApeZap,
+    },
     allowancesMap: allowancesMap ?? {},
   };
 }

--- a/src/core/store/modules/tokens/tokens.selectors.ts
+++ b/src/core/store/modules/tokens/tokens.selectors.ts
@@ -41,7 +41,7 @@ const selectSummaryData = createSelector([selectUserTokens], (userTokens) => {
 });
 
 const selectZapInTokens = createSelector([selectUserTokens], (userTokens) => {
-  return userTokens.filter(({ isZapable }) => isZapable);
+  return userTokens.filter(({ isZapperZapIn }) => isZapperZapIn);
 });
 
 const selectZapOutTokens = createSelector([selectTokensMap, selectUserTokensMap], (tokensMap, userTokensMap) => {
@@ -105,7 +105,9 @@ export function createToken(props: CreateTokenProps): TokenView {
     categories: tokenData?.metadata?.categories ?? [],
     description: tokenData?.metadata?.description ?? '',
     website: tokenData?.metadata?.website ?? '',
-    isZapable: tokenData?.supported.zapper ?? false,
+    isZapperZapIn: tokenData?.supported.zapperZapIn ?? false,
+    isZapperZapOut: tokenData?.supported.zapperZapOut ?? false,
+    isFtmApeZap: tokenData?.supported.ftmApeZap ?? false,
     allowancesMap: allowancesMap ?? {},
   };
 }

--- a/src/core/store/modules/vaults/vaults.selectors.ts
+++ b/src/core/store/modules/vaults/vaults.selectors.ts
@@ -96,12 +96,12 @@ const selectDeprecatedVaults = createSelector([selectVaults], (vaults): VaultVie
   const deprecatedVaults = vaults
     .filter((vault) => vault.hideIfNoDeposits)
     .map(({ DEPOSIT, token, ...rest }) => ({ token, ...DEPOSIT, ...rest }));
-  return deprecatedVaults.filter((vault) => toBN(vault.userDeposited).gt(0));
+  return deprecatedVaults.filter((vault) => vault.allowZapIn && toBN(vault.userDeposited).gt(0));
 });
 
 const selectDepositedVaults = createSelector([selectLiveVaults], (vaults): VaultView[] => {
   const depositVaults = vaults.map(({ DEPOSIT, token, ...rest }) => ({ token, ...DEPOSIT, ...rest }));
-  return depositVaults.filter((vault) => toBN(vault.userDeposited).gt(0));
+  return depositVaults.filter((vault) => vault.allowZapIn && toBN(vault.userDeposited).gt(0));
 });
 
 const selectVaultsOpportunities = createSelector([selectLiveVaults], (vaults): VaultView[] => {
@@ -110,6 +110,7 @@ const selectVaultsOpportunities = createSelector([selectLiveVaults], (vaults): V
   const depositVaults = vaults.map(({ DEPOSIT, token, ...rest }) => ({ token, ...DEPOSIT, ...rest }));
   const opportunities = depositVaults.filter(
     (vault) =>
+      vault.allowZapIn &&
       toBN(vault.userDeposited).lte(0) &&
       (toBN(vault.apyMetadata?.net_apy).gt(0) || vault.address === YFI_VAULT_ADDRESS)
   );

--- a/src/core/types/Token.ts
+++ b/src/core/types/Token.ts
@@ -19,7 +19,9 @@ export interface TokenView {
   categories: string[];
   description: string;
   website: string;
-  isZapable: boolean;
+  isZapperZapIn: boolean;
+  isZapperZapOut: boolean;
+  isFtmApeZap: boolean;
   allowancesMap: { [tokenAddress: string]: string };
 }
 

--- a/src/core/types/Token.ts
+++ b/src/core/types/Token.ts
@@ -19,9 +19,12 @@ export interface TokenView {
   categories: string[];
   description: string;
   website: string;
-  isZapperZapIn: boolean;
-  isZapperZapOut: boolean;
-  isFtmApeZap: boolean;
+  zaps: {
+    zapper?: boolean;
+    zapperZapIn?: boolean;
+    zapperZapOut?: boolean;
+    ftmApeZap?: boolean;
+  };
   allowancesMap: { [tokenAddress: string]: string };
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Display only Zapable Tokens by vault

## Related Issue

<!--- Please link to the issue here -->

https://linear.app/yearn/issue/WEB-1013/display-only-zapable-tokens-by-vault

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Users can identify tokens that can be used to deposit a specific vault.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

* Running the FE locally

## Screenshots (if appropriate):
