### PR TITLE
fix: height and width for vault details icon and nested h1 elements

### DIFF
--- a/src/client/components/app/Navbar/index.tsx
+++ b/src/client/components/app/Navbar/index.tsx
@@ -128,19 +128,17 @@ export const Navbar = ({
 
   const secondTitleEnabled = !!subTitle?.length;
 
-  const vaultText = (
-    <>
-      &nbsp;/&nbsp;<StyledText>{subTitle}</StyledText>
-    </>
-  );
+  const titleText = secondTitleEnabled ? <>{title}&nbsp;/&nbsp;</> : title;
 
   return (
     <StyledNavbar className={className}>
       {title && (
-        <StyledText toneDown={secondTitleEnabled}>
-          {titleLink ? <StyledLink to={titleLink}>{title}</StyledLink> : title}
-          {secondTitleEnabled && vaultText}
-        </StyledText>
+        <>
+          <StyledText toneDown={secondTitleEnabled}>
+            {titleLink ? <StyledLink to={titleLink}>{titleText}</StyledLink> : titleText}
+          </StyledText>
+          {secondTitleEnabled && <StyledText>{subTitle}</StyledText>}
+        </>
       )}
 
       <StyledNavbarActions>

--- a/src/client/components/app/TokenIcon/index.tsx
+++ b/src/client/components/app/TokenIcon/index.tsx
@@ -18,29 +18,30 @@ interface TokenIconProps {
   size?: TokenIconSize;
 }
 
-export const TokenIcon = ({ icon, symbol, size, ...props }: TokenIconProps) => {
+export const TokenIcon = ({ icon, symbol, size }: TokenIconProps) => {
   const src = icon === '' || !icon ? fallbackIcon : icon;
-  // TODO: use rem units instead of pixels
   let height;
   switch (size) {
     case 'big':
-      height = 42;
+      height = '4.2rem';
       break;
     case 'xBig':
-      height = 64;
+      height = '6.4rem';
       break;
     case 'xxBig':
-      height = 80;
+      height = '8rem';
       break;
     default:
-      height = 32;
+      height = '3.2rem';
       break;
   }
   const width = height;
+  const style = {
+    minWidth: width,
+    minHeight: height,
+    width: width,
+    height: height,
+  };
 
-  return (
-    <StyledTokenIcon {...props}>
-      {src && <Img alt={symbol ?? 'n/a'} width={width} height={height} src={src} />}
-    </StyledTokenIcon>
-  );
+  return <StyledTokenIcon>{src && <Img alt={symbol ?? 'n/a'} style={style} src={src} />}</StyledTokenIcon>;
 };


### PR DESCRIPTION
## Description

* Width/height weren't applying properly to the vault details icon due to the CSS being overridden by `max-width: 100%` on `img` elements - I didn't want to override this globally so instead I set `min-width` and `min-height` for the image
* Cleaned up a TODO and moved `px` values over to `rem`
* The navbar was also giving a console error because we had `h1` elements nested inside each other, so I fixed it

## Related Issue

Fixes #654

## Motivation and Context

* The dev console was throwing an error about nested H1 elements in the Navbar which is now fixed
* The icon for the vault details page now shows up correctly

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate):

Large icon now shows up under Overview:

![Screen Shot 2022-05-11 at 10 43 50 AM](https://user-images.githubusercontent.com/21136804/167903820-d8d6cc1d-6514-463e-a8ac-a98fa8fe5d60.png)


