### PR TITLE
feat: toggle for zero apy vault opportunities

### DIFF
--- a/src/client/routes/Vaults/index.tsx
+++ b/src/client/routes/Vaults/index.tsx
@@ -158,7 +158,7 @@ export const Vaults = () => {
   const dispatch = useAppDispatch();
   const isMounting = useIsMounting();
   // const { isTablet, isMobile, width: DWidth } = useWindowDimensions();
-  const { NETWORK_SETTINGS } = getConfig();
+  const { NETWORK_SETTINGS, CONTRACT_ADDRESSES } = getConfig();
   const walletIsConnected = useAppSelector(WalletSelectors.selectWalletIsConnected);
   const currentNetwork = useAppSelector(NetworkSelectors.selectCurrentNetwork);
   const currentNetworkSettings = NETWORK_SETTINGS[currentNetwork];
@@ -210,6 +210,10 @@ export const Vaults = () => {
       { header: t('dashboard.est-yearly-yield'), Component: <Amount value={estYearlyYeild} input="usdc" /> }
     );
   }
+
+  const filterVaults = (vault: VaultView) => {
+    return toBN(vault.apyMetadata?.net_apy).gt(0) || vault.address === CONTRACT_ADDRESSES.YVYFI;
+  };
 
   return (
     <ViewContainer>
@@ -477,6 +481,8 @@ export const Vaults = () => {
                 />
               }
               searching={opportunities.length > filteredVaults.length}
+              filterLabel="Show 0% APY"
+              filterBy={filterVaults}
               onAction={({ address }) => history.push(`/vault/${address}`)}
               initialSortBy="apy"
               wrap

--- a/src/core/store/modules/vaults/vaults.selectors.ts
+++ b/src/core/store/modules/vaults/vaults.selectors.ts
@@ -16,7 +16,6 @@ import {
   GeneralVaultView,
 } from '@types';
 import { toBN } from '@utils';
-import { getConfig } from '@config';
 
 import { createToken } from '../tokens/tokens.selectors';
 
@@ -105,13 +104,8 @@ const selectDepositedVaults = createSelector([selectLiveVaults], (vaults): Vault
 });
 
 const selectVaultsOpportunities = createSelector([selectLiveVaults], (vaults): VaultView[] => {
-  const YFI_VAULT_ADDRESS = getConfig().CONTRACT_ADDRESSES.YVYFI;
-
   const depositVaults = vaults.map(({ DEPOSIT, token, ...rest }) => ({ token, ...DEPOSIT, ...rest }));
-  const opportunities = depositVaults.filter(
-    (vault) => toBN(vault.userDeposited).lte(0) || vault.address === YFI_VAULT_ADDRESS
-  );
-
+  const opportunities = depositVaults.filter((vault) => toBN(vault.userDeposited).lte(0));
   return opportunities;
 });
 

--- a/src/core/store/modules/vaults/vaults.selectors.ts
+++ b/src/core/store/modules/vaults/vaults.selectors.ts
@@ -109,9 +109,7 @@ const selectVaultsOpportunities = createSelector([selectLiveVaults], (vaults): V
 
   const depositVaults = vaults.map(({ DEPOSIT, token, ...rest }) => ({ token, ...DEPOSIT, ...rest }));
   const opportunities = depositVaults.filter(
-    (vault) =>
-      toBN(vault.userDeposited).lte(0) &&
-      (toBN(vault.apyMetadata?.net_apy).gt(0) || vault.address === YFI_VAULT_ADDRESS)
+    (vault) => toBN(vault.userDeposited).lte(0) || vault.address === YFI_VAULT_ADDRESS
   );
 
   return opportunities;


### PR DESCRIPTION
## Description

* Adds a toggle to show 0% APY vaults, moved the filter for 0% APY out of the selector and into the page itself
* The toggle position is the default one in the component, which is different from what was requested in the issue but I think this looks fine personally? I can change it if needed

## Related Issue

Fixes #659

## Motivation and Context

* Allows users to show hidden vaults

## How Has This Been Tested?

Manually tested on vaults page

## Screenshots (if appropriate):

Desktop:
![Screen Shot 2022-05-12 at 12 18 22 PM](https://user-images.githubusercontent.com/21136804/168142366-7a1ab1f4-b460-442c-a593-3c21b5e84763.png)

![Screen Shot 2022-05-12 at 12 18 38 PM](https://user-images.githubusercontent.com/21136804/168142344-e0aab2b1-59fd-43e0-87d4-a592e39f620a.png)

Mobile:
![Screen Shot 2022-05-12 at 12 27 30 PM](https://user-images.githubusercontent.com/21136804/168143801-992baadc-2f98-4275-89d5-1e0e8193018c.png)

