### PR TITLE
fix: Tx modal token name convention

### DIFF
--- a/src/client/components/app/Transactions/Backscratcher/ClaimTx.tsx
+++ b/src/client/components/app/Transactions/Backscratcher/ClaimTx.tsx
@@ -60,7 +60,7 @@ export const BackscratcherClaimTx: FC<BackscratcherClaimTxProps> = ({ onClose, c
 
   const selectedLabOption = {
     address: selectedLab.address,
-    symbol: selectedTargetToken.name,
+    symbol: selectedTargetToken.symbol,
     icon: selectedTargetToken.icon,
     balance: selectedLab.YIELD.userDeposited,
     balanceUsdc: selectedLab.YIELD.userDepositedUsdc,

--- a/src/client/components/app/Transactions/Backscratcher/ReinvestTx.tsx
+++ b/src/client/components/app/Transactions/Backscratcher/ReinvestTx.tsx
@@ -70,7 +70,7 @@ export const BackscratcherReinvestTx: FC<BackscratcherReinvestTxProps> = ({ onCl
 
   const selectedLabOption = {
     address: selectedLab.address,
-    symbol: selectedTargetToken.name,
+    symbol: selectedTargetToken.symbol,
     icon: selectedTargetToken.icon,
     balance: selectedTargetVault.DEPOSIT.userDeposited,
     balanceUsdc: selectedTargetVault.DEPOSIT.userDepositedUsdc,
@@ -79,7 +79,7 @@ export const BackscratcherReinvestTx: FC<BackscratcherReinvestTxProps> = ({ onCl
 
   const selectedVaultOption = {
     address: selectedTargetToken.address,
-    symbol: selectedTargetToken.name,
+    symbol: selectedTargetToken.symbol,
     icon: selectedTargetToken.icon,
     balance: selectedTargetToken.balance,
     balanceUsdc: selectedTargetToken.balanceUsdc,

--- a/src/client/components/app/Transactions/DepositTx.tsx
+++ b/src/client/components/app/Transactions/DepositTx.tsx
@@ -183,9 +183,9 @@ export const DepositTx: FC<DepositTxProps> = ({
 
   const vaultsOptions = vaults
     .filter(({ address }) => allowVaultSelect || selectedVault.address === address)
-    .map(({ address, displayName, displayIcon, DEPOSIT, token, apyData, apyMetadata }) => ({
+    .map(({ address, displayIcon, DEPOSIT, token, apyData, apyMetadata }) => ({
       address,
-      symbol: displayName,
+      symbol: token.symbol,
       icon: displayIcon,
       balance: DEPOSIT.userDeposited,
       balanceUsdc: DEPOSIT.userDepositedUsdc,

--- a/src/client/components/app/Transactions/MigrateTx.tsx
+++ b/src/client/components/app/Transactions/MigrateTx.tsx
@@ -79,7 +79,7 @@ export const MigrateTx: FC<MigrateTxProps> = ({ header, onClose }) => {
 
   const sourceVault = {
     address: selectedVault.address,
-    symbol: selectedVault.displayName,
+    symbol: selectedVault.token.symbol,
     icon: selectedVault.displayIcon,
     balance: selectedVault.DEPOSIT.userDeposited,
     balanceUsdc: selectedVault.DEPOSIT.userDepositedUsdc,
@@ -88,7 +88,7 @@ export const MigrateTx: FC<MigrateTxProps> = ({ header, onClose }) => {
 
   const targetVault = {
     address: selectedVault.migrationTargetVault,
-    symbol: migrateToVault?.displayName ?? selectedVault.displayName,
+    symbol: migrateToVault?.token.symbol ?? selectedVault.token.symbol,
     icon: migrateToVault?.displayIcon ?? selectedVault.displayIcon,
     balance: migrateToVault?.DEPOSIT.userDeposited ?? '0',
     balanceUsdc: migrateToVault?.DEPOSIT.userDepositedUsdc ?? '0',

--- a/src/client/components/app/Transactions/WithdrawTx.tsx
+++ b/src/client/components/app/Transactions/WithdrawTx.tsx
@@ -166,7 +166,7 @@ export const WithdrawTx: FC<WithdrawTxProps> = ({ header, onClose, children, ...
 
   const selectedVaultOption = {
     address: selectedVault.address,
-    symbol: selectedVault.displayName,
+    symbol: selectedVault.token.symbol,
     icon: selectedVault.displayIcon,
     balance: underlyingTokenBalance,
     balanceUsdc: selectedVault.DEPOSIT.userDepositedUsdc,

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -101,6 +101,7 @@ const TokenData = styled.div`
 const TokenName = styled.div`
   width: 100%;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   text-align: center;
   font-size: 1.3rem;


### PR DESCRIPTION
## Description

- Updated token name for 'to vault' to use `token.symbol` instead of `displayName`.
- Think using the token symbol would fit better as the display name is already shown in the list.

## Related Issue

- Fixes #658

## Motivation and Context

- Token naming consistency.

## How Has This Been Tested?
- Manually check deposit modal on local environment.

## Screenshots (if appropriate):
![deposit](https://user-images.githubusercontent.com/83656073/168191607-5a8f3ab9-59e8-4752-9ba1-95e1e269db17.jpg)