### PR TITLE
fix: Breadcrumb title

### DIFF
--- a/src/client/components/app/Navbar/index.tsx
+++ b/src/client/components/app/Navbar/index.tsx
@@ -36,7 +36,7 @@ const StyledText = styled.h1<{ toneDown?: boolean }>`
   ${({ toneDown, theme }) =>
     toneDown &&
     `
-    color: ${theme.colors.textsVariant};
+    color: ${theme.colors.textsSecondary};
   `}
 `;
 

--- a/src/client/themes/classic/index.ts
+++ b/src/client/themes/classic/index.ts
@@ -19,6 +19,7 @@ const classic = {
     titlesVariant: '#FFFFFF',
     texts: '#CED5E3',
     textsVariant: '#7F8DA9',
+    textsSecondary: '#A8A8A8',
     disabled: '#CED5E3',
     icons: {
       primary: '#7F8DA9',
@@ -70,6 +71,7 @@ const classicTheme: DefaultTheme = {
     titlesVariant: classic.colors.titlesVariant,
     texts: classic.colors.texts,
     textsVariant: classic.colors.textsVariant,
+    textsSecondary: classic.colors.textsSecondary,
     surfaceVariant: classic.colors.surfaceVariant,
 
     secondaryVariantA: '#006AE3',

--- a/src/client/themes/cyberpunk/index.ts
+++ b/src/client/themes/cyberpunk/index.ts
@@ -25,6 +25,7 @@ const cyberpunkTheme: DefaultTheme = {
     titlesVariant: '#0CA7C9',
     texts: '#9dd9e6',
     textsVariant: '#0CA7C9',
+    textsSecondary: '#A8A8A8',
     surfaceVariant: '#FFF',
 
     secondaryVariantA: '#392850',

--- a/src/client/themes/dark/index.ts
+++ b/src/client/themes/dark/index.ts
@@ -17,6 +17,7 @@ const dark = {
     titlesVariant: '#FFFFFF',
     texts: '#A8A8A8',
     textsVariant: '#FFFFFF',
+    textsSecondary: '#A8A8A8',
     disabled: '#A8A8A8',
     icons: {
       primary: '#A8A8A8',
@@ -65,6 +66,7 @@ const darkTheme: DefaultTheme = {
     titlesVariant: dark.colors.titlesVariant,
     texts: dark.colors.texts,
     textsVariant: dark.colors.textsVariant,
+    textsSecondary: dark.colors.textsSecondary,
     surfaceVariant: dark.colors.surfaceVariant,
 
     secondaryVariantA: '#000000',

--- a/src/client/themes/explorer/index.ts
+++ b/src/client/themes/explorer/index.ts
@@ -33,6 +33,7 @@ const explorerTheme: DefaultTheme = {
     titlesVariant: '#AD3235',
     texts: '#FFF',
     textsVariant: '#AD3235',
+    textsSecondary: '#A8A8A8',
     surfaceVariant: '#FFF',
 
     secondaryVariantA: 'rgba(173, 50, 53, 0.5)',

--- a/src/client/themes/light/index.ts
+++ b/src/client/themes/light/index.ts
@@ -17,6 +17,7 @@ const light = {
     titlesVariant: '#0657F9',
     texts: '#475570',
     textsVariant: '#7F8DA9',
+    textsSecondary: '#A8A8A8',
     disabled: '#CED5E3',
     icons: {
       primary: '#CED5E3',
@@ -69,6 +70,7 @@ const lightTheme: DefaultTheme = {
     titlesVariant: light.colors.titlesVariant,
     texts: light.colors.texts,
     textsVariant: light.colors.textsVariant,
+    textsSecondary: light.colors.textsSecondary,
     surfaceVariant: light.colors.surfaceVariant,
 
     secondaryVariantA: '#000000',

--- a/src/client/themes/styled.d.ts
+++ b/src/client/themes/styled.d.ts
@@ -103,6 +103,7 @@ declare module 'styled-components' {
       titlesVariant: string;
       texts: string;
       textsVariant: string;
+      textsSecondary: string;
       surfaceVariant: string;
       // END REWORK
 


### PR DESCRIPTION
## Description

- Standardized breadcrumb title's color to `#A8A8A8` for all themes.
- Added `textsSecondary` prop to the theme.

## Related Issue

- Fixes #662

## Motivation and Context

- Standardize breadcrumb title's color for all themes.

## How Has This Been Tested?

- Locally by viewing breadcrumb titles for all themes.

## Screenshots (if appropriate):
![classic1](https://user-images.githubusercontent.com/83656073/168313939-b1c57be2-825d-49b1-b644-23b7c37ce52a.jpg)
![cyberpunk1](https://user-images.githubusercontent.com/83656073/168313962-ba2269ab-1d5f-4239-afa4-ac62d5a840f4.jpg)
![light1](https://user-images.githubusercontent.com/83656073/168314006-f4a2078f-43ce-48af-8d4c-ada6fc86f191.jpg)
![dark1](https://user-images.githubusercontent.com/83656073/168314016-b5db4053-5f90-4905-9731-80e45fafb568.jpg)
![explorer1](https://user-images.githubusercontent.com/83656073/168314025-4fcdee5d-8096-419c-835e-2bc7f3b66f7a.jpg)

