### PR TITLE
fix: move searching text to new line

### DIFF
--- a/src/client/components/common/Card/CardEmptyList/index.tsx
+++ b/src/client/components/common/Card/CardEmptyList/index.tsx
@@ -28,8 +28,10 @@ export const CardEmptyList: FC<CardEmptyListProps> = ({ children, text, searchin
     <StyledCardEmptyList onClick={onClick} {...props}>
       {text ?? (
         <Text>
-          <Text fontWeight="bold">{t('components.empty-list.text')}</Text>
-          {searching && <Text>{t('components.empty-list.searching-text')}</Text>}
+          <Text center fontWeight="bold">
+            {t('components.empty-list.text')}
+          </Text>
+          {searching && <Text center>{t('components.empty-list.searching-text')}</Text>}
         </Text>
       )}
     </StyledCardEmptyList>


### PR DESCRIPTION
## Description

* Updated the text component to use "center" 

## Related Issue

Fixes #666 

## Motivation and Context

* Fixes text style

## How Has This Been Tested?

Manually checked

## Screenshots (if appropriate):

<img width="989" alt="Screen Shot 2022-05-13 at 7 57 29 PM" src="https://user-images.githubusercontent.com/21136804/168406653-164392db-99bd-4a8e-bb5c-49243ec57b3f.png">

