### PR TITLE
Add Chinese translation for "portfolio"

### DIFF
--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -125,6 +125,7 @@
     "disclaimer": "声明",
     "ironbank": "Iron Bank",
     "labs": "实验室",
+    "portfolio": "投资组合",
     "settings": "设置",
     "vault": "机枪池详情",
     "vaults": "机枪池",


### PR DESCRIPTION
## Description

I attempted to contribute to Chinese site translation. Not sure if this is the correct way. 

If this works, I can continue with other missing i18n strings.

## How Has This Been Tested?

I run the app locally and saw the change was working.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/287189/168451913-694d0bf5-cdee-44e1-a0dc-3be3ac0b36bf.png)
