### PR TITLE
fix: show vaults with custom apy types by default

### DIFF
--- a/src/client/routes/Vaults/index.tsx
+++ b/src/client/routes/Vaults/index.tsx
@@ -212,7 +212,11 @@ export const Vaults = () => {
   }
 
   const filterVaults = (vault: VaultView) => {
-    return toBN(vault.apyMetadata?.net_apy).gt(0) || vault.address === CONTRACT_ADDRESSES.YVYFI;
+    return (
+      toBN(vault.apyMetadata?.net_apy).gt(0) ||
+      isCustomApyType(vault.apyType) ||
+      vault.address === CONTRACT_ADDRESSES.YVYFI
+    );
   };
 
   return (


### PR DESCRIPTION
## Description

Show vaults with custom APY types by default in opportunities section

## Motivation and Context

New Vaults and other custom ones should be displayed in main front page without the need of the show/hide toggle

## How Has This Been Tested?

locally and preview build

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/18649057/168898471-76d60e5a-edaf-4495-8ba3-d4bd10d0fd1a.png)
