### PR TITLE
feat: temporarily disable arbitrum earnings

### DIFF
--- a/src/config/constants/index.ts
+++ b/src/config/constants/index.ts
@@ -82,7 +82,7 @@ const NETWORK_SETTINGS: NetworkSettings = {
     zapsEnabled: false,
     labsEnabled: false,
     ironBankEnabled: false,
-    earningsEnabled: true,
+    earningsEnabled: false,
     notifyEnabled: false,
     blockExplorerUrl: 'https://arbiscan.io',
     txConfirmations: 2,


### PR DESCRIPTION
## Description

Temporarily disable Arbitrum earnings

## Related Issue

Earnings not being updated properly in subgraph
![image](https://user-images.githubusercontent.com/18649057/168906081-95d82bbc-6e27-4a22-b504-9dbcfa5f4dad.png)

## Motivation and Context

Users might want to withdraw thinking they have not earned anything based on wrong data displayed.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/18649057/168906790-50d64d6e-b13c-421f-9fc2-e1994c0a642a.png)
