### PR TITLE
feat: use private zapper api key

### DIFF
--- a/src/core/frameworks/yearnSdk/index.ts
+++ b/src/core/frameworks/yearnSdk/index.ts
@@ -7,7 +7,7 @@ export class YearnSdkImpl implements YearnSdk {
   private instances: Map<Network, Yearn<SdkNetwork>> = new Map<Network, Yearn<SdkNetwork>>();
 
   constructor({ web3Provider, config }: { web3Provider: Web3Provider; config: Config }) {
-    const { SUPPORTED_NETWORKS, CONTRACT_ADDRESSES, YEARN_SUBGRAPH_ID, YEARN_SUBGRAPH_KEY } = config;
+    const { SUPPORTED_NETWORKS, CONTRACT_ADDRESSES, YEARN_SUBGRAPH_ID, YEARN_SUBGRAPH_KEY, ZAPPER_API_KEY } = config;
 
     const isLedger = isLedgerLive();
     SUPPORTED_NETWORKS.forEach((network) => {
@@ -16,6 +16,7 @@ export class YearnSdkImpl implements YearnSdk {
       const networkId = getNetworkId(network) as SdkNetwork;
       const sdkInstance = new Yearn(networkId, {
         provider,
+        zapper: ZAPPER_API_KEY,
         partnerId: isLedger && networkId === 1 ? CONTRACT_ADDRESSES.LEDGER_PARTNER_ID : undefined,
         ...(YEARN_SUBGRAPH_KEY && {
           subgraph: {


### PR DESCRIPTION
## Description

Initiate sdk instance with zapper private api key

## Motivation and Context

Zapper will be deprecating soon the public API key that is used by default in the SDK.

## How Has This Been Tested?

To be tested in preview build

