### PR TITLE
fix: Filter zapable token for wallet

### DIFF
--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -264,13 +264,15 @@ export const Portfolio = () => {
               grow: '1',
             },
           ]}
-          data={userTokens.map((token) => ({
-            ...token,
-            displayName: token.symbol,
-            displayIcon: token.icon ?? '',
-            tokenBalance: normalizeAmount(token.balance, token.decimals),
-            invest: null,
-          }))}
+          data={userTokens
+            .filter((token) => token.isZapable)
+            .map((token) => ({
+              ...token,
+              displayName: token.symbol,
+              displayIcon: token.icon ?? '',
+              tokenBalance: normalizeAmount(token.balance, token.decimals),
+              invest: null,
+            }))}
           initialSortBy="balanceUsdc"
           wrap
           filterBy={filterDustTokens}


### PR DESCRIPTION
## Description

- Added `filter` to filter only zapable tokens
- Checked that sUSD is not zapable in yearn-sdk
- Checked that sUSD yVault is not deprecated

## Related Issue

- #683

## Motivation and Context

- Improve user experience by not showing unzapable vaults

## How Has This Been Tested?

- Locally by confirming [sUSD ](https://etherscan.io/address/0x57ab1ec28d129707052df4df418d58a2d46d5f51)not appearing in the wallet container

## Screenshots (if appropriate):
- [sUSD yVault](https://etherscan.io/address/0xa5cA62D95D24A4a350983D5B8ac4EB8638887396#code) is shown to be not deprecated by checking [AddressesGenerator_VAULT_V2](https://etherscan.io/address/0x437758d475f70249e03eda6be23684ad1fc375f0#readContract)'s `assetDeprecated` and confirming vault is being fetched by checking `assetsAddresses`

![AddressesGenerator_VAULT_V2_0x437758d475f70249e03eda6be23684ad1fc375f0](https://user-images.githubusercontent.com/83656073/169290225-62101067-9a6a-402b-855c-a3e834bbc6cc.jpg)

- sUSD token not showing anymore

![susd](https://user-images.githubusercontent.com/83656073/169291809-191ad3b9-1db3-4770-8a3f-853d5173d5f8.jpg)

