### PR TITLE
feat: zappable tokens shortcut [WEB-1524]

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -98,7 +98,7 @@
       "wallet-balance": "Wallet Balance",
       "withdraw": "Withdraw",
       "zap-guidance": {
-        "desc": "Or select a token from your wallet to Zap",
+        "desc": "⚡ Or select a token from your wallet to Zap",
         "view-all": "View all"
       }
     }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -98,9 +98,8 @@
       "wallet-balance": "Wallet Balance",
       "withdraw": "Withdraw",
       "zap-guidance": {
-        "part-1": "Or",
-        "part-2": "select a token",
-        "part-3": "in your wallet to ZAP"
+        "desc": "Or select a token from your wallet to Zap",
+        "view-all": "View all"
       }
     }
   },

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -136,13 +136,6 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
     `
       background-color: ${theme.colors.secondary};
     `}
-
-  ${({ right }) =>
-    right &&
-    `
-    margin-right: 0;
-    margin-left: auto;
-  `}
 `;
 
 const ZappableTokensList = styled.div`
@@ -405,7 +398,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
                 </ZappableTokenButton>
               ))}
 
-              <ZappableTokenButton right outline onClick={openSearchList}>
+              <ZappableTokenButton outline onClick={openSearchList}>
                 {t('components.transaction.zap-guidance.view-all')}
               </ZappableTokenButton>
             </ZappableTokensList>

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -122,14 +122,48 @@ const TokenIconContainer = styled.div`
   width: 100%;
 `;
 
+const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean }>`
+  font-size: 1.2rem;
+  height: 2.4rem;
+  padding: 0 0.8rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  overflow: hidden;
+
+  ${({ selected, theme }) =>
+    selected &&
+    `
+      background-color: ${theme.colors.secondary};
+    `}
+
+  ${({ right }) =>
+    right &&
+    `
+    margin-right: 0;
+    margin-left: auto;
+  `}
+`;
+
+const ZappableTokensList = styled.div`
+  display: flex;
+  overflow: hidden;
+  overflow-x: auto;
+  margin-top: 0.8rem;
+  grid-gap: 0.8rem;
+  width: 100%;
+`;
+
 const ZapMessageContainer = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
   border-radius: ${({ theme }) => theme.globalRadius};
   background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
   padding: ${({ theme }) => theme.layoutPadding};
   font-size: 1.4rem;
   width: 100%;
+  overflow: hidden;
 `;
 
 const TokenSelector = styled.div<{ onClick?: () => void; center?: boolean }>`
@@ -171,13 +205,6 @@ const Header = styled.div`
   font-size: 1.6rem;
   text-transform: capitalize;
   color: ${({ theme }) => theme.colors.txModalColors.text};
-`;
-
-const HighlightText = styled.span`
-  text-decoration: underline;
-  color: ${({ theme }) => theme.colors.primary};
-  padding: 0 0.5rem;
-  cursor: pointer;
 `;
 
 const scaleTransitionTime = 300;
@@ -271,6 +298,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
   const { t } = useAppTranslation('common');
 
   let listItems: SearchListItem[] = [];
+  let zappableItems: SearchListItem[] = [];
   let selectedItem: SearchListItem = {
     id: selectedToken.address,
     icon: selectedToken.icon,
@@ -289,6 +317,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
         };
       })
       .sort((a, b) => amountToNumber(b.value) - amountToNumber(a.value));
+    zappableItems = listItems.slice(0, 5);
     listItems.sort((a, b) => (a.id === selectedItem.id ? -1 : 1));
   }
 
@@ -360,11 +389,26 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
             </TokenData>
           )}
         </TokenInfo>
-        {listItems?.length > 1 && displayGuidance && (
-          <ZapMessageContainer onClick={openSearchList}>
-            ⚡ {t('components.transaction.zap-guidance.part-1')}{' '}
-            <HighlightText> {t('components.transaction.zap-guidance.part-2')} </HighlightText>{' '}
-            {t('components.transaction.zap-guidance.part-3')}
+
+        {zappableItems?.length > 1 && displayGuidance && (
+          <ZapMessageContainer>
+            ⚡ {t('components.transaction.zap-guidance.desc')}
+            <ZappableTokensList>
+              {zappableItems.slice(0, 4).map((item) => (
+                <ZappableTokenButton
+                  key={item.id}
+                  outline
+                  selected={item.id === selectedItem.id}
+                  onClick={() => (onSelectedTokenChange ? onSelectedTokenChange(item.id) : undefined)}
+                >
+                  {item.label}
+                </ZappableTokenButton>
+              ))}
+
+              <ZappableTokenButton right outline onClick={openSearchList}>
+                {t('components.transaction.zap-guidance.view-all')}
+              </ZappableTokenButton>
+            </ZappableTokensList>
           </ZapMessageContainer>
         )}
       </>

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -135,6 +135,7 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
     selected &&
     `
       background-color: ${theme.colors.secondary};
+      color: ${theme.colors.titlesVariant};
     `}
 `;
 

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -131,7 +131,7 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
   text-overflow: ellipsis;
   flex-shrink: 0;
   overflow: hidden;
-  max-width: 6.5rem;
+  max-width: 6.8rem;
 
   ${({ selected, theme }) =>
     selected &&
@@ -156,7 +156,7 @@ const ZapMessageContainer = styled.div`
   align-items: flex-start;
   border-radius: ${({ theme }) => theme.globalRadius};
   background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
-  padding: ${({ theme }) => theme.layoutPadding};
+  padding: 0.8rem;
   font-size: 1.2rem;
   width: 100%;
   overflow: hidden;

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -390,7 +390,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
           <ZapMessageContainer>
             {t('components.transaction.zap-guidance.desc')}
             <ZappableTokensList>
-              {zappableItems.slice(0, 4).map((item) => (
+              {zappableItems.map((item) => (
                 <ZappableTokenButton
                   key={item.id}
                   outline

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -122,16 +122,18 @@ const TokenIconContainer = styled.div`
   width: 100%;
 `;
 
-const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean }>`
+const ZappableTokenButton = styled(Button)<{ selected?: boolean; viewAll?: boolean }>`
   display: block;
   font-size: 1.2rem;
   height: 2.4rem;
   padding: 0 0.8rem;
   white-space: nowrap;
   text-overflow: ellipsis;
-  flex-shrink: 0;
   overflow: hidden;
+  width: -webkit-fill-available;
+  // NOTE - hack fallback if fill-available is not supported
   max-width: 6.6rem;
+  max-width: max-content;
 
   ${({ selected, theme }) =>
     selected &&
@@ -139,11 +141,20 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
       background-color: ${theme.colors.secondary};
       color: ${theme.colors.titlesVariant};
     `}
+  ${({ viewAll }) =>
+    viewAll &&
+    `
+      flex-shrink: 0;
+    `}
 `;
 
 const ZappableTokensList = styled.div`
   display: flex;
-  flex-wrap: wrap;
+  // NOTE This will make the list with css grid, an alternative to flexbox wrapping.
+  // We should leave this piece of code here because I think we will need to change the style.
+  // grid-template-columns: repeat(auto-fit, minmax(3rem, max-content));
+  // grid-auto-flow: column;
+  // flex-wrap: wrap;
   overflow: hidden;
   margin-top: 0.8rem;
   grid-gap: 0.8rem;
@@ -401,7 +412,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
                 </ZappableTokenButton>
               ))}
 
-              <ZappableTokenButton outline onClick={openSearchList}>
+              <ZappableTokenButton viewAll outline onClick={openSearchList}>
                 {t('components.transaction.zap-guidance.view-all')}
               </ZappableTokenButton>
             </ZappableTokensList>

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -161,7 +161,7 @@ const ZapMessageContainer = styled.div`
   border-radius: ${({ theme }) => theme.globalRadius};
   background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
   padding: ${({ theme }) => theme.layoutPadding};
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   width: 100%;
   overflow: hidden;
 `;
@@ -392,7 +392,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
 
         {zappableItems?.length > 1 && displayGuidance && (
           <ZapMessageContainer>
-            ⚡ {t('components.transaction.zap-guidance.desc')}
+            {t('components.transaction.zap-guidance.desc')}
             <ZappableTokensList>
               {zappableItems.slice(0, 4).map((item) => (
                 <ZappableTokenButton

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -123,6 +123,7 @@ const TokenIconContainer = styled.div`
 `;
 
 const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean }>`
+  display: block;
   font-size: 1.2rem;
   height: 2.4rem;
   padding: 0 0.8rem;
@@ -130,6 +131,7 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
   text-overflow: ellipsis;
   flex-shrink: 0;
   overflow: hidden;
+  max-width: 6.5rem;
 
   ${({ selected, theme }) =>
     selected &&
@@ -141,8 +143,8 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
 
 const ZappableTokensList = styled.div`
   display: flex;
+  flex-wrap: wrap;
   overflow: hidden;
-  overflow-x: auto;
   margin-top: 0.8rem;
   grid-gap: 0.8rem;
   width: 100%;

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -131,7 +131,7 @@ const ZappableTokenButton = styled(Button)<{ selected?: boolean; right?: boolean
   text-overflow: ellipsis;
   flex-shrink: 0;
   overflow: hidden;
-  max-width: 6.8rem;
+  max-width: 6.6rem;
 
   ${({ selected, theme }) =>
     selected &&

--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -324,7 +324,7 @@ export const TxTokenInput: FC<TxTokenInputProps> = ({
         };
       })
       .sort((a, b) => amountToNumber(b.value) - amountToNumber(a.value));
-    zappableItems = listItems.slice(0, 5);
+    zappableItems = listItems.slice(0, 4);
     listItems.sort((a, b) => (a.id === selectedItem.id ? -1 : 1));
   }
 

--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -93,7 +93,7 @@ const ActionsTabs = styled(Tabs)``;
 const VaultActions = styled(Card)`
   display: flex;
   flex-direction: column;
-  width: 42rem;
+  width: 50.4rem;
   align-self: stretch;
   padding: 0;
 


### PR DESCRIPTION
## Description
Should add, in vault details and modal, a quick action to change between tokens with available amounts

![image](https://user-images.githubusercontent.com/78362532/169691602-a2e15b43-2278-42fa-888a-7d1358aefee9.png)

## How Has This Been Tested?
Local env, desktop, mobile down to 375px.

## Screenshots (if appropriate):
Result:
![image](https://user-images.githubusercontent.com/78362532/169692279-ce72908c-9bdc-4a30-a5c9-d1c75f5419d1.png)

Mobile:
![image](https://user-images.githubusercontent.com/78362532/169692264-845dd840-f68f-4539-b1ec-a0573d5cc71f.png)