### PR TITLE
fix: Modal zap layout on iphone se

### DIFF
--- a/src/client/components/app/Transactions/components/TxTokenInput.tsx
+++ b/src/client/components/app/Transactions/components/TxTokenInput.tsx
@@ -130,6 +130,13 @@ const ZapMessageContainer = styled.div`
   padding: ${({ theme }) => theme.layoutPadding};
   font-size: 1.4rem;
   width: 100%;
+
+  @media (max-width: 400px) {
+    font-size: 1.3rem;
+    padding-left: 0rem;
+    padding-right: 0rem;
+    justify-content: center;
+  }
 `;
 
 const TokenSelector = styled.div<{ onClick?: () => void; center?: boolean }>`


### PR DESCRIPTION
## Description

- Added CSS changes for devices with `400px` width or lower
- `400px` is used as that's the point where the text would wrap to the second line
- Removed padding so that font size can be at `1.3rem`, else with the existing padding, font size has to be reduced to `1.2rem`
- Centered the text so that the container's left and right are aligned
- `341px` will be the next point where the text would wrap again

## Related Issue

- Fixes #692

## Motivation and Context

- Better display for iPhone SE users

## How Has This Been Tested?

- Locally by viewing the updated modal layout

## Screenshots (if appropriate):
![zap](https://user-images.githubusercontent.com/83656073/169698711-939035b9-7a08-4846-a5e1-fcdcb2e58ef3.jpg)

