### PR TITLE
fix: disable zaps on unsupported networks

### DIFF
--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -107,7 +107,7 @@ export const Portfolio = () => {
 
   const appStatus = useAppSelector(AppSelectors.selectAppStatus);
   const servicesEnabled = useAppSelector(AppSelectors.selectServicesEnabled);
-  const zapperEnabled = servicesEnabled.zapper;
+  const zapperEnabled = servicesEnabled.zapper && currentNetwork === 'mainnet';
   const tokensListStatus = useAppSelector(TokensSelectors.selectWalletTokensStatus);
   const generalLoading = (appStatus.loading || tokensListStatus.loading || isMounting) && !activeModal;
   const userTokensLoading = generalLoading && !userTokens.length;

--- a/src/core/store/common/tokensByAsset.selectors.ts
+++ b/src/core/store/common/tokensByAsset.selectors.ts
@@ -10,15 +10,17 @@ import { LabsSelectors } from '../modules/labs/labs.selectors';
 import { TokensSelectors } from '../modules/tokens/tokens.selectors';
 import { AppSelectors } from '../modules/app/app.selectors';
 import { createToken } from '../modules/tokens/tokens.selectors';
+import { NetworkSelectors } from '../modules/network/network.selectors';
 
 const { selectVaultsMap } = VaultsSelectors;
 const { selectLabsMap } = LabsSelectors;
 const { selectTokensMap, selectTokensUser } = TokensSelectors;
 const { selectServicesEnabled } = AppSelectors;
+const { selectCurrentNetwork } = NetworkSelectors;
 
 export const selectDepositTokenOptionsByAsset = createSelector(
-  [selectVaultsMap, selectLabsMap, selectTokensMap, selectTokensUser, selectServicesEnabled],
-  (vaultsMap, labsMap, tokensMap, tokensUser, servicesEnabled) =>
+  [selectVaultsMap, selectLabsMap, selectTokensMap, selectTokensUser, selectServicesEnabled, selectCurrentNetwork],
+  (vaultsMap, labsMap, tokensMap, tokensUser, servicesEnabled, currentNetwork) =>
     memoize((assetAddress?: string): TokenView[] => {
       if (!assetAddress) return [];
 
@@ -26,7 +28,8 @@ export const selectDepositTokenOptionsByAsset = createSelector(
       const assetData = vaultsMap[assetAddress] ? vaultsMap[assetAddress] : labsMap[assetAddress];
       if (!assetData) return [];
 
-      const zapperDisabled = !servicesEnabled.zapper && assetData.metadata.zapInWith === 'zapperZapIn';
+      const zapperDisabled =
+        (!servicesEnabled.zapper && assetData.metadata.zapInWith === 'zapperZapIn') || currentNetwork !== 'mainnet';
       const mainVaultToken = zapperDisabled ? assetData.token : assetData.metadata.defaultDisplayToken;
       const depositTokenAddresses = [mainVaultToken];
       if (!zapperDisabled) {
@@ -46,8 +49,8 @@ export const selectDepositTokenOptionsByAsset = createSelector(
 );
 
 export const selectWithdrawTokenOptionsByAsset = createSelector(
-  [selectVaultsMap, selectLabsMap, selectTokensMap, selectTokensUser, selectServicesEnabled],
-  (vaultsMap, labsMap, tokensMap, tokensUser, servicesEnabled) =>
+  [selectVaultsMap, selectLabsMap, selectTokensMap, selectTokensUser, selectServicesEnabled, selectCurrentNetwork],
+  (vaultsMap, labsMap, tokensMap, tokensUser, servicesEnabled, currentNetwork) =>
     memoize((assetAddress?: string): TokenView[] => {
       if (!assetAddress) return [];
 
@@ -55,7 +58,8 @@ export const selectWithdrawTokenOptionsByAsset = createSelector(
       const assetData = vaultsMap[assetAddress] ? vaultsMap[assetAddress] : labsMap[assetAddress];
       if (!assetData) return [];
 
-      const zapperDisabled = !servicesEnabled.zapper && assetData.metadata.zapOutWith === 'zapperZapOut';
+      const zapperDisabled =
+        (!servicesEnabled.zapper && assetData.metadata.zapOutWith === 'zapperZapOut') || currentNetwork !== 'mainnet';
       const mainVaultToken = zapperDisabled ? assetData.token : assetData.metadata.defaultDisplayToken;
       const withdrawTokenAddresses = [mainVaultToken];
       if (!zapperDisabled) {


### PR DESCRIPTION
## Description

Disables zaps for networks other than Ethereum Mainnet

## Motivation and Context

Vault deposit and withdraw modals on fantom and arbitrum are displaying other tokens as if they allow zaps.

A better solution can be worked after to make it dynamically and refactor this temp solution.

## How Has This Been Tested?

Tested locally on all networks.

