### PR TITLE
feat: `AmountInput` UI, disabled and error states

### DIFF
--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -42,7 +42,12 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
     }
   `}
 
-  ${({ error, theme }) => error && `color: ${theme.colors.txModalColors.error};`}
+  ${({ error, theme }) =>
+    error &&
+    `
+    color: ${theme.colors.txModalColors.error};
+    border: 1px solid red;
+  `}
 
   ${() => `
     ::-webkit-outer-spin-button,

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -32,13 +32,13 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
   ${({ readOnly, theme }) =>
     readOnly &&
     `
-    border: 1px solid ${theme.colors.textsVariant};
-    color: ${theme.colors.textsVariant};
+    border: 1px solid ${theme.colors.txModalColors.onBackgroundVariantColor};
+    color: ${theme.colors.txModalColors.onBackgroundVariantColor};
     cursor: default;
     background: transparent;
 
     &::placeholder {
-      color: ${theme.colors.textsVariant};
+      color: ${theme.colors.txModalColors.onBackgroundVariantColor};
     }
   `}
 
@@ -62,8 +62,10 @@ const MaxButton = styled(Button)`
   position: absolute;
   right: 1.6rem;
   border-radius: ${({ theme }) => theme.globalRadius};
-  width: min-content;
+  border-width: 1px;
   margin-left: 0.5rem;
+  height: 2.4rem;
+  font-size: 1.2rem;
 `;
 
 export interface AmountInputProps extends BoxProps {
@@ -104,7 +106,7 @@ export const AmountInput = ({
           aria-label={label}
         />
         {maxAmount && (
-          <MaxButton outline onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined}>
+          <MaxButton outline onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined} disabled={disabled}>
             {maxLabel}
           </MaxButton>
         )}

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -26,7 +26,7 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
   width: 100%;
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.txModalColors.textContrast};
+    color: ${({ theme }) => theme.colors.input?.placeholder || theme.colors.textsVariant};
   }
 
   ${({ readOnly, theme }) =>

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -26,7 +26,7 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
   width: 100%;
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.input?.placeholder || theme.colors.textsVariant};
+    color: ${({ theme }) => theme.colors.txModalColors.textContrast};
   }
 
   ${({ readOnly, theme }) =>
@@ -38,7 +38,7 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
     background: transparent;
 
     &::placeholder {
-      color: ${theme.colors.txModalColors.onBackgroundVariantColor};
+      color: ${theme.colors.input?.placeholder || theme.colors.textsVariant};
     }
   `}
 

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -70,6 +70,10 @@ const MaxButton = styled(Button)`
   font-size: 1.2rem;
 `;
 
+const StyledCaption = styled(Text)`
+  color: ${({ theme }) => theme.colors.input?.placeholder || theme.colors.textsVariant};
+`;
+
 export interface AmountInputProps extends BoxProps {
   amount?: string;
   onAmountChange?: (amount: string) => void;
@@ -114,9 +118,9 @@ export const AmountInput = ({
         )}
       </InputContainer>
       {message && (
-        <Text fontSize="1.2rem" lineHeight="1.6rem" marginTop="0.4rem">
+        <StyledCaption fontSize="1.2rem" lineHeight="1.6rem" marginTop="0.4rem">
           {message}
-        </Text>
+        </StyledCaption>
       )}
     </Box>
   );

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -72,6 +72,9 @@ const MaxButton = styled(Button)`
 
 const StyledCaption = styled(Text)`
   color: ${({ theme }) => theme.colors.input?.placeholder || theme.colors.textsVariant};
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+  margin-top: 0.4rem;
 `;
 
 export interface AmountInputProps extends BoxProps {
@@ -117,11 +120,7 @@ export const AmountInput = ({
           </MaxButton>
         )}
       </InputContainer>
-      {message && (
-        <StyledCaption fontSize="1.2rem" lineHeight="1.6rem" marginTop="0.4rem">
-          {message}
-        </StyledCaption>
-      )}
+      {message && <StyledCaption>{message}</StyledCaption>}
     </Box>
   );
 };

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -40,6 +40,8 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
     &::placeholder {
       color: ${theme.colors.input?.placeholder || theme.colors.textsVariant};
     }
+
+    cursor: not-allowed;
   `}
 
   ${({ error, theme }) =>

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -32,8 +32,8 @@ const StyledInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
   ${({ readOnly, theme }) =>
     readOnly &&
     `
-    border: 1px solid ${theme.colors.txModalColors.onBackgroundVariantColor};
-    color: ${theme.colors.txModalColors.onBackgroundVariantColor};
+    border: 1px solid ${theme.colors.input?.placeholder || theme.colors.textsVariant};
+    color: ${theme.colors.input?.placeholder || theme.colors.textsVariant};
     cursor: default;
     background: transparent;
 

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -115,7 +115,7 @@ export const AmountInput = ({
           aria-label={label}
         />
         {maxAmount && !disabled && (
-          <MaxButton outline onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined} disabled={disabled}>
+          <MaxButton outline onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined}>
             {maxLabel}
           </MaxButton>
         )}

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -112,7 +112,7 @@ export const AmountInput = ({
         )}
       </InputContainer>
       {message && (
-        <Text fontSize="1.2rem" lineHeight="1.6rem">
+        <Text fontSize="1.2rem" lineHeight="1.6rem" marginTop="0.4rem">
           {message}
         </Text>
       )}

--- a/src/client/components/app/AmountInput/index.tsx
+++ b/src/client/components/app/AmountInput/index.tsx
@@ -105,7 +105,7 @@ export const AmountInput = ({
           type="number"
           aria-label={label}
         />
-        {maxAmount && (
+        {maxAmount && !disabled && (
           <MaxButton outline onClick={onAmountChange ? () => onAmountChange(maxAmount) : undefined} disabled={disabled}>
             {maxLabel}
           </MaxButton>

--- a/src/client/components/common/Text/index.tsx
+++ b/src/client/components/common/Text/index.tsx
@@ -16,7 +16,7 @@ const h3Mixin = css`
   font-weight: bold;
 `;
 
-const StyledDiv = styled.span<StyledSystemProps & { ellipsis?: boolean; heading?: HeadingType }>`
+const StyledDiv = styled.p<StyledSystemProps & { ellipsis?: boolean; heading?: HeadingType }>`
   color: ${({ heading, theme }) => (heading ? theme.colors.titles : null)};
   ${({ heading }) => heading === 'h1' && h1Mixin}
   ${({ heading }) => heading === 'h2' && h2Mixin}

--- a/src/client/themes/dark/index.ts
+++ b/src/client/themes/dark/index.ts
@@ -134,6 +134,10 @@ const darkTheme: DefaultTheme = {
         color: dark.colors.button.disabled.text,
       },
     },
+
+    input: {
+      placeholder: '#555555',
+    },
   },
 };
 

--- a/src/client/themes/light/index.ts
+++ b/src/client/themes/light/index.ts
@@ -138,6 +138,10 @@ const lightTheme: DefaultTheme = {
         color: light.colors.button.disabled.text,
       },
     },
+
+    input: {
+      placeholder: '#7F8DA9',
+    },
   },
 };
 

--- a/src/client/themes/styled.d.ts
+++ b/src/client/themes/styled.d.ts
@@ -172,6 +172,10 @@ declare module 'styled-components' {
           color: string;
         };
       };
+
+      input?: {
+        placeholder: string;
+      };
     };
   }
 


### PR DESCRIPTION
## Description

Amount input component:

- Match colors and spacings to designs
- Disabled state
- Error state (red border)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Match designs

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and observed the changes, refer to screenshots below

## Screenshots (if appropriate):

<img width="694" alt="yearn_finance" src="https://user-images.githubusercontent.com/78794805/178144813-d3581ca8-171d-4a87-a340-1fda828e1a39.png">

<img width="655" alt="yearn_finance" src="https://user-images.githubusercontent.com/78794805/178144838-5a69b82f-b3ee-47b9-b01f-1fe68b16e79f.png">

<img width="708" alt="yearn_finance" src="https://user-images.githubusercontent.com/78794805/178144860-6055bca2-c4c1-4b2c-9feb-e3b1a73cbddb.png">

