### PR TITLE
fix: temporarily change subgraph endpoint

### DIFF
--- a/src/core/frameworks/yearnSdk/index.ts
+++ b/src/core/frameworks/yearnSdk/index.ts
@@ -7,7 +7,7 @@ export class YearnSdkImpl implements YearnSdk {
   private instances: Map<Network, Yearn<SdkNetwork>> = new Map<Network, Yearn<SdkNetwork>>();
 
   constructor({ web3Provider, config }: { web3Provider: Web3Provider; config: Config }) {
-    const { SUPPORTED_NETWORKS, CONTRACT_ADDRESSES, YEARN_SUBGRAPH_ID, YEARN_SUBGRAPH_KEY, ZAPPER_API_KEY } = config;
+    const { SUPPORTED_NETWORKS, CONTRACT_ADDRESSES, YEARN_SUBGRAPH_KEY, ZAPPER_API_KEY } = config;
 
     const isLedger = isLedgerLive();
     SUPPORTED_NETWORKS.forEach((network) => {
@@ -20,7 +20,9 @@ export class YearnSdkImpl implements YearnSdk {
         partnerId: isLedger && networkId === 1 ? CONTRACT_ADDRESSES.LEDGER_PARTNER_ID : undefined,
         ...(YEARN_SUBGRAPH_KEY && {
           subgraph: {
-            mainnetSubgraphEndpoint: `https://gateway.thegraph.com/api/${YEARN_SUBGRAPH_KEY}/subgraphs/id/${YEARN_SUBGRAPH_ID}`,
+            // TODO revert to using official subgraph once its working again
+            // mainnetSubgraphEndpoint: `https://gateway.thegraph.com/api/${YEARN_SUBGRAPH_KEY}/subgraphs/id/${YEARN_SUBGRAPH_ID}`,
+            mainnetSubgraphEndpoint: `https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet`,
           },
         }),
       });


### PR DESCRIPTION
## Description

- Temporarily change to a stable and synced mainnet subgraph endpoint 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- Official yearn mainnet subgraph continues to have issues on earnings/holdings data
