### PR TITLE
fix: disable signed approvals as default on gnosis app

### DIFF
--- a/src/core/store/modules/app/app.actions.ts
+++ b/src/core/store/modules/app/app.actions.ts
@@ -55,6 +55,7 @@ const initApp = createAsyncThunk<void, void, ThunkAPI>('app/initApp', async (_ar
   } else if (isGnosisApp()) {
     const walletName = 'Gnosis Safe';
     if (network.current !== 'mainnet') await dispatch(NetworkActions.changeNetwork({ network: 'mainnet' }));
+    if (settings.signedApprovalsEnabled) await dispatch(SettingsActions.toggleSignedApprovals());
     await dispatch(WalletActions.walletSelect({ walletName, network: 'mainnet' }));
   } else if (isCoinbaseApp()) {
     const walletName = 'Coinbase Wallet';


### PR DESCRIPTION
## Description

Disable signed approvals as default option when using as a gnosis app

## Motivation and Context

Signed approvals not working on gnosis safe app