### PR TITLE
refactor: Use `SimpleTransaction` component

### DIFF
--- a/src/client/components/app/Transactions/Gauges/StakeTx.tsx
+++ b/src/client/components/app/Transactions/Gauges/StakeTx.tsx
@@ -93,11 +93,12 @@ export const StakeTx: FC<StakeTxProps> = ({ header, onClose }) => {
   return (
     <SimpleTransaction
       actions={txActions}
-      onClose={onClose}
+      amount={amount}
+      header={t('components.transaction.stake')}
       onAmountChange={setAmount}
+      onClose={onClose}
       onTransactionCompletedDismissed={onTransactionCompletedDismissed}
       selectedAsset={gauge.token}
-      amount={amount}
       status={{ error }}
       transactionCompleted={!!stakeStatus.executed}
     />

--- a/src/client/components/app/Transactions/Gauges/StakeTx.tsx
+++ b/src/client/components/app/Transactions/Gauges/StakeTx.tsx
@@ -2,17 +2,9 @@ import { FC, useState, useEffect } from 'react';
 
 import { useAppSelector, useAppDispatch, useAppTranslation, useExecuteThunk } from '@hooks';
 import { NetworkSelectors, WalletSelectors, GaugesActions, GaugesSelectors } from '@store';
-import {
-  toBN,
-  toWei,
-  normalizeAmount,
-  USDC_DECIMALS,
-  validateNetwork,
-  validateAllowance,
-  validateAmount,
-} from '@utils';
+import { toBN, toWei, validateNetwork, validateAllowance, validateAmount } from '@utils';
 
-import { Transaction } from '../Transaction';
+import { SimpleTransaction } from '../SimpleTransaction';
 
 export interface StakeTxProps {
   header?: string;
@@ -65,24 +57,7 @@ export const StakeTx: FC<StakeTxProps> = ({ header, onClose }) => {
     walletNetwork,
   });
 
-  const gaugeOption = {
-    address: gauge.address,
-    symbol: gauge.token.symbol,
-    icon: '',
-    balance: gauge.DEPOSIT.userDeposited,
-    balanceUsdc: gauge.DEPOSIT.userDepositedUsdc,
-    decimals: gauge.token.decimals,
-  };
-
-  const amountValue = toBN(amount).times(normalizeAmount(gauge.token.priceUsdc, USDC_DECIMALS)).toString();
-  const expectedAmount = amount;
-  const expectedAmountValue = amountValue;
-
-  const sourceError = networkError || allowanceError || inputError;
-
-  const targetStatus = {
-    error: approveStakeStatus.error || stakeStatus.error,
-  };
+  const error = networkError || allowanceError || inputError;
 
   const onTransactionCompletedDismissed = () => {
     if (onClose) onClose();
@@ -116,26 +91,15 @@ export const StakeTx: FC<StakeTxProps> = ({ header, onClose }) => {
   ];
 
   return (
-    <Transaction
-      transactionLabel={header}
-      transactionCompleted={!!stakeStatus.executed}
-      onTransactionCompletedDismissed={onTransactionCompletedDismissed}
-      sourceHeader={t('components.transaction.from-wallet')}
-      sourceAssetOptions={[gauge.token]}
-      selectedSourceAsset={gauge.token}
-      sourceAmount={amount}
-      sourceAmountValue={amountValue}
-      onSourceAmountChange={setAmount}
-      sourceStatus={{ error: sourceError }}
-      targetHeader={t('components.transaction.to-gauge')}
-      targetAssetOptions={[gaugeOption]}
-      selectedTargetAsset={gaugeOption}
-      targetAmountDisabled={false}
-      targetAmount={expectedAmount}
-      targetAmountValue={expectedAmountValue}
-      targetStatus={targetStatus}
+    <SimpleTransaction
       actions={txActions}
       onClose={onClose}
+      onAmountChange={setAmount}
+      onTransactionCompletedDismissed={onTransactionCompletedDismissed}
+      selectedAsset={gauge.token}
+      amount={amount}
+      status={{ error }}
+      transactionCompleted={!!stakeStatus.executed}
     />
   );
 };

--- a/src/client/components/app/Transactions/Gauges/UnstakeTx.tsx
+++ b/src/client/components/app/Transactions/Gauges/UnstakeTx.tsx
@@ -73,11 +73,12 @@ export const UnstakeTx: FC<UnstakeTxProps> = ({ header, onClose }) => {
   return (
     <SimpleTransaction
       actions={txActions}
-      onClose={onClose}
+      amount={amount}
+      header={t('components.transaction.unstake')}
       onAmountChange={setAmount}
+      onClose={onClose}
       onTransactionCompletedDismissed={onTransactionCompletedDismissed}
       selectedAsset={gaugeOption}
-      amount={amount}
       status={{ error: sourceError }}
       transactionCompleted={!!unstakeStatus.executed}
     />

--- a/src/client/components/app/Transactions/Gauges/UnstakeTx.tsx
+++ b/src/client/components/app/Transactions/Gauges/UnstakeTx.tsx
@@ -2,9 +2,9 @@ import { FC, useState, useEffect } from 'react';
 
 import { useAppSelector, useAppDispatch, useAppTranslation, useExecuteThunk } from '@hooks';
 import { NetworkSelectors, WalletSelectors, GaugesActions, GaugesSelectors } from '@store';
-import { toBN, normalizeAmount, toWei, USDC_DECIMALS, validateNetwork, validateAmount } from '@utils';
+import { toWei, validateNetwork, validateAmount } from '@utils';
 
-import { Transaction } from '../Transaction';
+import { SimpleTransaction } from '../SimpleTransaction';
 
 export interface UnstakeTxProps {
   header?: string;
@@ -47,12 +47,7 @@ export const UnstakeTx: FC<UnstakeTxProps> = ({ header, onClose }) => {
     decimals: gauge.token.decimals,
   };
 
-  const amountValue = toBN(amount).times(normalizeAmount(gauge.token.priceUsdc, USDC_DECIMALS)).toString();
-  const expectedAmount = amount;
-  const expectedAmountValue = amountValue;
-
   const sourceError = networkError || inputError;
-  const targetError = unstakeStatus.error;
 
   const onTransactionCompletedDismissed = () => {
     if (onClose) onClose();
@@ -76,26 +71,15 @@ export const UnstakeTx: FC<UnstakeTxProps> = ({ header, onClose }) => {
   ];
 
   return (
-    <Transaction
-      transactionLabel={header}
-      transactionCompleted={!!unstakeStatus.executed}
-      onTransactionCompletedDismissed={onTransactionCompletedDismissed}
-      sourceHeader={t('components.transaction.from-gauge')}
-      sourceAssetOptions={[gaugeOption]}
-      selectedSourceAsset={gaugeOption}
-      sourceAmount={amount}
-      sourceAmountValue={amountValue}
-      onSourceAmountChange={setAmount}
-      sourceStatus={{ error: sourceError }}
-      targetHeader={t('components.transaction.to-wallet')}
-      targetAssetOptions={[gauge.token]}
-      selectedTargetAsset={gauge.token}
-      targetAmountDisabled={false}
-      targetAmount={expectedAmount}
-      targetAmountValue={expectedAmountValue}
-      targetStatus={{ error: targetError }}
+    <SimpleTransaction
       actions={txActions}
       onClose={onClose}
+      onAmountChange={setAmount}
+      onTransactionCompletedDismissed={onTransactionCompletedDismissed}
+      selectedAsset={gaugeOption}
+      amount={amount}
+      status={{ error: sourceError }}
+      transactionCompleted={!!unstakeStatus.executed}
     />
   );
 };

--- a/src/client/components/app/Transactions/SimpleTransaction.tsx
+++ b/src/client/components/app/Transactions/SimpleTransaction.tsx
@@ -14,6 +14,7 @@ import { TxError } from './components/TxError';
 interface SimpleTransactionProps {
   actions: Action[];
   amount: string;
+  header: string;
   selectedAsset: Asset;
   status: Status;
   transactionCompleted: boolean;
@@ -30,6 +31,7 @@ export const SimpleTransaction: FC<SimpleTransactionProps> = (props) => {
   const {
     actions,
     amount,
+    header,
     selectedAsset,
     status,
     transactionCompleted,
@@ -55,7 +57,7 @@ export const SimpleTransaction: FC<SimpleTransactionProps> = (props) => {
   }`;
 
   return (
-    <TxContainer onClose={onClose} header={t('components.transaction.stake')}>
+    <TxContainer onClose={onClose} header={header}>
       <Box display="grid" gridTemplateColumns="repeat(2, 1fr)" gridColumnGap={'2.4rem'}>
         <Dropdown
           label={'Choose token'} // TODO: Add translation

--- a/src/client/components/app/Transactions/Transaction.tsx
+++ b/src/client/components/app/Transactions/Transaction.tsx
@@ -10,12 +10,12 @@ import { TxTokenInput } from './components/TxTokenInput';
 import { TxError } from './components/TxError';
 import { TxStatus } from './components/TxStatus';
 
-interface Status {
+export interface Status {
   loading?: boolean;
   error?: string | null;
 }
 
-interface Action {
+export interface Action {
   label: string;
   onAction: () => void;
   status: Status;
@@ -23,7 +23,7 @@ interface Action {
   contrast?: boolean;
 }
 
-interface Asset {
+export interface Asset {
   address: string;
   symbol: string;
   icon?: string;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Follow up on https://github.com/yearn/yearn-finance-v3/pull/741

Replace the usage of the `Transaction` component in [Gauges/StakeTx](https://github.com/yearn/yearn-finance-v3/blob/feat/veYFI/src/client/components/app/Transactions/Gauges/StakeTx.tsx#L119) and [Gauges/Unstake](https://github.com/yearn/yearn-finance-v3/blob/feat/veYFI/src/client/components/app/Transactions/Gauges/UnstakeTx.tsx#L79) with `SimpleTransaction` component.

Uses the error and success state of the `Transaction` component.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Simplify the component to its essentials.

## How Has This Been Tested?

Ran locally, refer to screenshots below

## Screenshots (if appropriate):

### Stake
<img width="2352" alt="Screen Shot 2022-08-08 at 1 52 59 pm" src="https://user-images.githubusercontent.com/78794805/183335747-3ad6eb72-40f0-485e-a5eb-d21385c6ebc2.png">

### Unstake
<img width="2352" alt="Screen Shot 2022-08-08 at 1 53 50 pm" src="https://user-images.githubusercontent.com/78794805/183335849-9dab0212-e536-490b-bc04-04f7426112b9.png">


### Error
<img width="2352" alt="Screen Shot 2022-08-08 at 12 33 48 pm" src="https://user-images.githubusercontent.com/78794805/183333096-86117b9d-7471-45e3-8750-d5cb40dd7f56.png">

### Success
<img width="2352" alt="Screen Shot 2022-08-08 at 1 05 27 pm" src="https://user-images.githubusercontent.com/78794805/183333102-8594aaf3-d9fa-43df-870b-dbb120931ad8.png">
