### PR TITLE
fix: withdraw with permit using ledger with metamask

### DIFF
--- a/src/core/frameworks/ethers/index.ts
+++ b/src/core/frameworks/ethers/index.ts
@@ -36,7 +36,7 @@ const _signTypedData = async (
   domain: TypedDataDomain,
   types: Record<string, TypedDataField[]>,
   value: Record<string, any>
-) => {
+): Promise<string> => {
   const typedData = JSON.stringify({
     types: {
       EIP712Domain: [
@@ -78,11 +78,16 @@ export const signTypedData = async (
   // NOTE: Use Ethers signTypedData once it gets a stable release
   // const signature = await signer._signTypedData(domain, types, value);
   const signature = await _signTypedData(signer, domain, types, value);
+
+  // NOTE: Invalid Ledger + Metamask signatures need to be reconstructed until issue is solved and released
+  // https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/152
+  // https://github.com/MetaMask/metamask-extension/issues/10240
+  const isInvalidLedgerSignature = signature.endsWith('00') || signature.endsWith('01');
+
+  if (!isInvalidLedgerSignature) return signature;
+
   const { r, s, v, recoveryParam } = ethers.utils.splitSignature(signature);
-  const reconstructedSignature = ethers.utils.joinSignature({ r, s, v, recoveryParam });
-  console.log({ signature, r, s, v, recoveryParam });
-  console.log(reconstructedSignature);
-  return reconstructedSignature;
+  return ethers.utils.joinSignature({ r, s, v, recoveryParam });
 };
 
 export const getContract = (


### PR DESCRIPTION
## Description

Fix invalid signature issue on withdraw from vault with permit when using a ledger hw wallet

## Related Issue

https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/152
https://github.com/MetaMask/eth-ledger-bridge-keyring/issues/151
https://github.com/MetaMask/metamask-extension/issues/10240

## Motivation and Context

Users should be able to use Metamask + Ledger to withdraw from vaults using permit. Currently the generated signature is invalid due to incorrect V parameter of https://eips.ethereum.org/EIPS/eip-712. We will temporarily reconstruct the signature using Ethers utils with correct V parameter until issue is solved.

## How Has This Been Tested?

Tested with a Metamask + Ledger wallet 
