### PR TITLE
feat: display ycrv migration warning

### DIFF
--- a/public/locales/en/labs.json
+++ b/public/locales/en/labs.json
@@ -1,4 +1,8 @@
 {
+  "migrate-card": {
+    "desc-1": "yveCRV and yvBOOST tokens are no longer supported and will not continue generating yield, but you can easily migrate them to our new and improved tokens and start earning that sweet sweet yield.",
+    "header": "Supercharge your yield with yCRV"
+  },
   "no-labs-card": {
     "header": "No Labs yet on {{network}}",
     "text": "Check back later for some new experiments."
@@ -8,5 +12,6 @@
     "desc-2": "As with all Yearn products, you are responsible for educating yourself on the details, and for actively managing your holdings.",
     "desc-3": "Welcome to the Lab, but proceed with caution, anon.",
     "header": "These are not risks for ants"
-  }
+  },
+  "migrate-warning": "Please migrate to yCRV. This vault will no longer generate yield"
 }

--- a/src/client/components/app/ActionButtons/index.tsx
+++ b/src/client/components/app/ActionButtons/index.tsx
@@ -19,7 +19,7 @@ const AlertButton = styled.div`
   align-items: center;
   justify-content: center;
   border-radius: 0.8rem;
-  border: 2px solid ${({ theme }) => theme.colors.vaultActionButton.selected.borderColor};
+  border: 2px solid ${({ theme }) => theme.colors.vaultActionButton.color};
   background: ${({ theme }) => theme.colors.vaultActionButton.iconFill};
   width: 2.8rem;
   height: 2.8rem;

--- a/src/client/routes/Labs/index.tsx
+++ b/src/client/routes/Labs/index.tsx
@@ -38,6 +38,12 @@ const StyledRecommendationsCard = styled(RecommendationsCard)``;
 
 const StyledSliderCard = styled(SliderCard)``;
 
+const MigrationWarningCard = styled(SliderCard)`
+  background: ${({ theme }) => theme.alerts.warning.background};
+  color: ${({ theme }) => theme.alerts.warning.color};
+  border: 2px solid ${({ theme }) => theme.alerts.warning.background};
+`;
+
 const OpportunitiesCard = styled(DetailCard)`
   @media ${device.tablet} {
     .col-name {
@@ -161,6 +167,7 @@ export const Labs = () => {
                 external: true,
               },
             ]}
+            alert={t('labs:migrate-warning')}
           />
         );
       case YVBOOST:
@@ -183,6 +190,7 @@ export const Labs = () => {
                 external: true,
               },
             ]}
+            alert={t('labs:migrate-warning')}
           />
         );
       default:
@@ -237,6 +245,17 @@ export const Labs = () => {
               <p>{t('labs:risks-card.desc-1')}</p>
               <p>{t('labs:risks-card.desc-2')}</p>
               <p>{t('labs:risks-card.desc-3')}</p>
+            </Text>
+          }
+        />
+      )}
+
+      {!opportunitiesLoading && currentNetworkSettings.labsEnabled && holdings.length > 0 && (
+        <MigrationWarningCard
+          header={t('labs:migrate-card.header')}
+          Component={
+            <Text>
+              <p>{t('labs:migrate-card.desc-1')}</p>
             </Text>
           }
         />


### PR DESCRIPTION
## Description

- Display yCrv migration warning

## Motivation and Context

- Warn yvBoost and yveCRV holders about their ability to migrate to yCRV to continue generating yield. 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/18649057/193417487-3a34e5ba-de3a-44ad-9023-1765f9996686.png)
