### PR TITLE
Fix gap when lacking content #789

### DIFF
--- a/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
+++ b/src/client/components/app/VaultDetail/VaultDetailPanels.tsx
@@ -205,6 +205,7 @@ const Row = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  width: 100%;
   justify-content: center;
   gap: ${({ theme }) => theme.layoutPadding};
 `;


### PR DESCRIPTION
Fill up whole container width.

## Description

<!--- Describe your changes -->

## Related Issue

#789 

## Motivation and Context

Prettier look :) 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/6696080/199640545-465909bc-cddd-461c-b6ef-b4c4ff7d3b5e.png">
no gap at the right side
