### PR TITLE
feat: allow load as iframe from new gnosis domain

### DIFF
--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -17,7 +17,7 @@ export const isLedgerLive = () => {
 };
 
 export const isGnosisApp = () => {
-  return isLoadedInOtherDomain('gnosis');
+  return isLoadedInOtherDomain('gnosis') || isLoadedInOtherDomain('safe');
 };
 
 export const isCoinbaseApp = () => {


### PR DESCRIPTION
## Description

- Allow app to load as an iframe from new Gnosis domain https://app.safe.global

## Motivation and Context

- Users cant connect wallet when yearn loads as a gnosis app on new domain.

## How Has This Been Tested?

Testing with Gnosis team