### PR TITLE
chore: rebase-veyfi-to-master github action

### DIFF
--- a/.github/workflows/rebase-veyfi-to-master.yml
+++ b/.github/workflows/rebase-veyfi-to-master.yml
@@ -1,0 +1,21 @@
+name: rebase veyfi-master to master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  rebase:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: git
+      run: |
+        git checkout veyfi-master
+        git rebase -Xours master
+        git push origin veyfi-master --force


### PR DESCRIPTION
## Description
Added a gh workflow that syncs the veyfi-master branch with the master branch when a new change is pushed to master.

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

We deploy & run the veyfi frontend off the same repo but with different env variables. 

## How Has This Been Tested?

Tested local changes in the master branch on my fork.

## Screenshots (if appropriate):
