### PR TITLE
refactor: veYFI time

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@web3-onboard/trezor": "^2.3.2",
     "@web3-onboard/uauth": "^2.0.0",
     "@web3-onboard/walletconnect": "^2.2.0",
-    "@yfi/sdk": "3.0.0-alpha.10",
+    "@yfi/sdk": "3.0.0-alpha.11",
     "awilix": "7.0.2",
     "axios": "0.21.2",
     "bignumber.js": "9.0.2",

--- a/src/client/containers/VotingEscrowTabs/LockTab.tsx
+++ b/src/client/containers/VotingEscrowTabs/LockTab.tsx
@@ -5,7 +5,19 @@ import { useAppSelector, useAppTranslation, useDebounce, useExecuteThunk, useIsM
 import { AlertsActions, VotingEscrowsActions, VotingEscrowsSelectors, WalletSelectors } from '@store';
 import { AmountInput } from '@components/app';
 import { Box, Text, Button } from '@components/common';
-import { humanize, toBN, toUnit, toWei, validateAllowance, validateAmount, toWeeks, getTimeUntil } from '@utils';
+import {
+  humanize,
+  toBN,
+  toUnit,
+  toWei,
+  validateAllowance,
+  validateAmount,
+  toWeeks,
+  getTimeUntil,
+  fromWeeks,
+  toTime,
+  toSeconds,
+} from '@utils';
 
 const MAX_LOCK_TIME = '209'; // Weeks
 const MIN_LOCK_TIME = '1'; // Weeks
@@ -42,6 +54,9 @@ export const LockTab = () => {
 
   const hasLockedAmount = toBN(votingEscrow?.DEPOSIT.userDeposited).gt(0);
   const willLock = !!debouncedLockAmount;
+  const unlockTime = toBN(Date.now())
+    .plus(fromWeeks(toTime(debouncedLockTime)))
+    .toNumber();
   const resultAmount =
     hasLockedAmount && !willLock && votingEscrow
       ? toUnit(votingEscrow?.DEPOSIT.userBalance, votingEscrow.decimals)
@@ -73,9 +88,9 @@ export const LockTab = () => {
       tokenAddress: votingEscrow.token.address,
       votingEscrowAddress: votingEscrow.address,
       amount: debouncedLockAmount,
-      time: hasLockedAmount ? undefined : toBN(debouncedLockTime).toNumber(),
+      time: hasLockedAmount ? undefined : toSeconds(unlockTime),
     });
-  }, [debouncedLockAmount, debouncedLockTime, votingEscrow?.token]);
+  }, [debouncedLockAmount, debouncedLockTime, votingEscrow?.token.address]);
 
   useEffect(() => {
     if (!votingEscrow || !hasLockedAmount || willLock) return;
@@ -117,7 +132,7 @@ export const LockTab = () => {
       tokenAddress: votingEscrow.token.address,
       votingEscrowAddress: votingEscrow.address,
       amount: lockAmount,
-      time: parseInt(lockTime),
+      time: toSeconds(unlockTime),
     });
   };
 

--- a/src/client/containers/VotingEscrowTabs/ManageLockTab.tsx
+++ b/src/client/containers/VotingEscrowTabs/ManageLockTab.tsx
@@ -107,7 +107,9 @@ export const ManageLockTab = () => {
             label={t('veyfi:manage-tab.increase-period')}
             amount={lockTime}
             onAmountChange={setLockTime}
-            maxAmount={toBN(MAX_LOCK_TIME).minus(weeksToUnlock).toString()}
+            maxAmount={
+              toBN(MAX_LOCK_TIME).minus(weeksToUnlock).gt(0) ? toBN(MAX_LOCK_TIME).minus(weeksToUnlock).toString() : '0'
+            }
             disabled={!hasDeposits}
             error={lockTimeError}
             message="min 1"

--- a/src/client/routes/VotingEscrow/index.tsx
+++ b/src/client/routes/VotingEscrow/index.tsx
@@ -87,9 +87,7 @@ export const VotingEscrowPage = () => {
             </Box>
             <Box center>
               <StyledValue>
-                <Text fontFamily="Aeonik Mono">
-                  {votingEscrow?.unlockDate?.toLocaleDateString('en-CA').replaceAll('-', '.') ?? '-'}
-                </Text>
+                <Text fontFamily="Aeonik Mono">{votingEscrow?.unlockDate?.toLocaleDateString('en-CA') ?? '-'}</Text>
               </StyledValue>
               <Text fontSize="1.2rem" lineHeight="1.6rem" mt=".8rem">
                 Expiration for the lock

--- a/src/core/store/modules/votingEscrows/votingEscrows.actions.ts
+++ b/src/core/store/modules/votingEscrows/votingEscrows.actions.ts
@@ -11,7 +11,7 @@ import {
   VotingEscrowDynamic,
   VotingEscrowTransactionType,
   VotingEscrowUserMetadata,
-  Weeks,
+  Seconds,
 } from '@types';
 import { getNetwork, validateNetwork, parseError, toWei } from '@utils';
 
@@ -117,7 +117,7 @@ const getExpectedTransactionOutcome = createAsyncThunk<
     tokenAddress: Address;
     votingEscrowAddress: Address;
     amount?: Unit;
-    time?: Weeks;
+    time?: Seconds;
   },
   ThunkAPI
 >(
@@ -237,7 +237,7 @@ const lock = createAsyncThunk<
     tokenAddress: Address;
     votingEscrowAddress: Address;
     amount: Unit;
-    time: Weeks;
+    time: Seconds;
   },
   ThunkAPI
 >(
@@ -337,7 +337,7 @@ const extendLockTime = createAsyncThunk<
   {
     tokenAddress: Address;
     votingEscrowAddress: Address;
-    time: Weeks;
+    time: Seconds;
   },
   ThunkAPI
 >(

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,8 +1,9 @@
 import BigNumber from 'bignumber.js';
 
-import { GeneralLabView, SummaryData, Unit, Wei } from '@types';
+import { GeneralLabView, Milliseconds, Seconds, SummaryData, Unit, Wei } from '@types';
 
 import { toBN, toUnit } from './format';
+import { roundToWeek, toSeconds, YEAR } from './time';
 
 interface CalculateSharesAmountProps {
   decimals: string;
@@ -50,4 +51,13 @@ export function computeSummaryData(labs: Pick<GeneralLabView, 'apyData' | 'DEPOS
     totalEarnings: totalEarnings.toString(),
     estYearlyYield: totalDeposits.isZero() ? '0' : totalEarnings.div(totalDeposits).toString(),
   };
+}
+
+const MAX_LOCK: Seconds = toSeconds(roundToWeek(YEAR * 4));
+
+export function getVotingPower(lockAmount: Wei, unlockTime: Milliseconds): Wei {
+  const duration = toSeconds(roundToWeek(unlockTime)) - toSeconds(Date.now());
+  if (duration <= 0) return '0';
+  if (duration >= MAX_LOCK) return lockAmount;
+  return toBN(lockAmount).div(MAX_LOCK).decimalPlaces(0, 1).times(duration).toString();
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -6,7 +6,7 @@ export const WEEK: Milliseconds = DAY * 7;
 export const YEAR: Milliseconds = DAY * 365;
 
 export function toTime(time: number | string | undefined): Milliseconds {
-  return Number(time ?? 0);
+  return Number(time || 0);
 }
 
 export function toMilliseconds(time?: Seconds): Milliseconds {
@@ -21,11 +21,15 @@ export function toWeeks(time?: Milliseconds): Weeks {
   return Math.floor(toTime(time) / WEEK);
 }
 
+export function fromWeeks(time?: Weeks): Milliseconds {
+  return toTime(time) * WEEK;
+}
+
 export function getTimeUntil(time?: Milliseconds): Milliseconds {
   const duration = toTime(time) - Date.now();
   return duration < 0 ? 0 : duration;
 }
 
-export function roundToWeek(time?: Seconds): Milliseconds {
+export function roundToWeek(time?: Milliseconds): Milliseconds {
   return Math.floor(toTime(time) / WEEK) * WEEK;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5719,10 +5719,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@yfi/sdk@3.0.0-alpha.10":
-  version "3.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-3.0.0-alpha.10.tgz#e9abe6cd68876aa4b4b3672d06afe25fb8d1d6fd"
-  integrity sha512-+F92vUaCP+PY3zld7MOrO34cyRzpUgpBYp5YwYNOANQ5qXuRUBKGhV/UVH6eLw/IQeTi5RmmkMaJJT/1Agcq1Q==
+"@yfi/sdk@3.0.0-alpha.11":
+  version "3.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-3.0.0-alpha.11.tgz#d73b6d669be04928de5fcea2fb8773b6071f74ae"
+  integrity sha512-gHYQOzlf/+tp5uNA7vYN0WRDO9oH1WCv3XlnPYKJGOuu4XebaCl2BVtIdGelZEhAVGLhVXDD7bT+N8aIMS7k9w==
   dependencies:
     "@cowprotocol/cow-sdk" "1.0.0-RC.5"
     bignumber.js "9.0.1"


### PR DESCRIPTION
## Description

- Refactor internal usage of `weeks` in favor of `seconds` as time units
- Display a more conventional time format

## Related Issue

- https://github.com/yearn/yearn-sdk/pull/322

## Motivation and Context

- Allow more granular units avoiding issues when rounding.
